### PR TITLE
fix!: include dist/ in published package

### DIFF
--- a/.claude/rules/coding-standards.md
+++ b/.claude/rules/coding-standards.md
@@ -90,7 +90,8 @@ if (!field) {
 
 ## Code Style
 
-- Use `.ts` extensions for all local imports (ESM with `--experimental-strip-types`)
+- Use `.js` extensions for all local imports in `src/` (ESM, required for `tsgo` emit)
+- Test files may use `.ts` extensions when importing from `src/` (tsx loader resolves them)
 - Return early, avoid nested else statements
 - No comments except for complex business logic or non-obvious workarounds
 - Use `function` declarations for named exports; arrow functions for callbacks and inline use
@@ -136,7 +137,7 @@ test/integration/       # End-to-end generator tests with real SQLite
 
 ### Test Runner
 
-- `node:test` with `--experimental-strip-types` (no transpile step)
+- `node:test` with `tsx` loader (`--import=tsx`)
 - `better-sqlite3` for integration tests (in-memory SQLite)
 
 ### Scripts
@@ -145,7 +146,7 @@ test/integration/       # End-to-end generator tests with real SQLite
 {
   "scripts": {
     "check": "tsgo --noEmit",
-    "test": "node --test --experimental-strip-types 'test/**/*.test.ts'",
+    "test": "node --test --import=tsx 'test/**/*.test.ts'",
     "pretest": "npm run check"
   }
 }
@@ -155,10 +156,10 @@ Run: `npm test` (type check + run)
 
 ## Toolchain
 
-- `tsgo` for type checking (`tsgo --noEmit`)
+- `tsgo` for type checking (`tsgo --noEmit`) and building (`tsgo --project tsconfig.build.json`)
 - `biome` for linting and formatting (`biome check .`, `biome check --write .`)
-- Node >= 22 with `--experimental-strip-types` for runtime
-- `allowImportingTsExtensions: true` + `noEmit: true` in tsconfig
+- `tsx` loader for runtime TypeScript (resolves `.js` → `.ts` imports)
+- `noEmit: true` in base tsconfig; `tsconfig.build.json` overrides to `noEmit: false` for emit
 
 ## IDE Diagnostics
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,6 +27,8 @@ jobs:
         run: npm run check
       - name: Test
         run: npm test
+      - name: Build
+        run: npm run build
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "@typescript/native-preview": "latest",
         "@typespec/compiler": "^1.9.0",
         "better-sqlite3": "^12.6.2",
-        "drizzle-orm": "^1.0.0-beta.15-859cf75"
+        "drizzle-orm": "^1.0.0-beta.15-859cf75",
+        "tsx": "^4.21.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -548,6 +549,448 @@
       ],
       "engines": {
         "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -1774,6 +2217,48 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1919,6 +2404,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1940,6 +2440,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/github-from-package": {
@@ -2729,6 +3242,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -3139,6 +3662,26 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "lint": "biome check .",
     "fix": "biome check --write .",
     "format": "biome format --write .",
-    "test": "node --test --experimental-strip-types 'test/**/*.test.ts'",
-    "pretest": "npm run check"
+    "test": "node --test --import=tsx 'test/**/*.test.ts'",
+    "pretest": "npm run check",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@babel/generator": "^7.29.1",
@@ -37,7 +38,8 @@
     "@typescript/native-preview": "latest",
     "@typespec/compiler": "^1.9.0",
     "better-sqlite3": "^12.6.2",
-    "drizzle-orm": "^1.0.0-beta.15-859cf75"
+    "drizzle-orm": "^1.0.0-beta.15-859cf75",
+    "tsx": "^4.21.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -1,10 +1,10 @@
-import { generateDescribe } from "./generators/describe-generator.ts";
-import { generateIndex } from "./generators/index-generator.ts";
-import { generateRelations } from "./generators/relations-generator.ts";
-import { generateSchema } from "./generators/schema-generator.ts";
-import { generateTypes } from "./generators/types-generator.ts";
-import { buildRelationGraph } from "./ir/relation-graph.ts";
-import type { EnumDef, TableDef } from "./ir/types.ts";
+import { generateDescribe } from "./generators/describe-generator.js";
+import { generateIndex } from "./generators/index-generator.js";
+import { generateRelations } from "./generators/relations-generator.js";
+import { generateSchema } from "./generators/schema-generator.js";
+import { generateTypes } from "./generators/types-generator.js";
+import { buildRelationGraph } from "./ir/relation-graph.js";
+import type { EnumDef, TableDef } from "./ir/types.js";
 
 export interface EmitterConfig {
   packageName: string;

--- a/src/codegen/ast-helpers.ts
+++ b/src/codegen/ast-helpers.ts
@@ -1,7 +1,7 @@
 import { generate } from "@babel/generator";
 import { parse, parseExpression } from "@babel/parser";
 import type { ObjectExpression } from "@babel/types";
-import { RawCode } from "./stringify.ts";
+import { RawCode } from "./stringify.js";
 
 function isObjectExpression(node: unknown): node is ObjectExpression {
   return (

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1,4 +1,4 @@
-export type { ChainMethod } from "./ast-helpers.ts";
+export type { ChainMethod } from "./ast-helpers.js";
 export {
   arrayLiteral,
   arrowFn,
@@ -9,5 +9,5 @@ export {
   importDecl,
   objectLiteral,
   quoted,
-} from "./ast-helpers.ts";
-export { RawCode, stringifyObject } from "./stringify.ts";
+} from "./ast-helpers.js";
+export { RawCode, stringifyObject } from "./stringify.js";

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,5 +1,5 @@
 import type { DecoratorContext, Model, ModelProperty } from "@typespec/compiler";
-import { StateKeys } from "./lib.ts";
+import { StateKeys } from "./lib.js";
 
 export function $table(
   context: DecoratorContext,

--- a/src/generators/column-mapper.ts
+++ b/src/generators/column-mapper.ts
@@ -1,6 +1,6 @@
-import { type ChainMethod, chainCall, fnCall, objectLiteral, quoted } from "../codegen/index.ts";
-import type { FieldDef, TableDef } from "../ir/types.ts";
-import { toTableVariableName } from "./naming.ts";
+import { type ChainMethod, chainCall, fnCall, objectLiteral, quoted } from "../codegen/index.js";
+import type { FieldDef, TableDef } from "../ir/types.js";
+import { toTableVariableName } from "./naming.js";
 
 export function mapFieldToColumn(field: FieldDef, table: TableDef): string {
   const calls: ChainMethod[] = [];

--- a/src/generators/describe-generator.ts
+++ b/src/generators/describe-generator.ts
@@ -1,7 +1,7 @@
-import { importDecl, objectLiteral } from "../codegen/index.ts";
-import type { Relation, RelationGraph } from "../ir/relation-graph.ts";
-import type { TableDef } from "../ir/types.ts";
-import { toTableVariableName } from "./naming.ts";
+import { importDecl, objectLiteral } from "../codegen/index.js";
+import type { Relation, RelationGraph } from "../ir/relation-graph.js";
+import type { TableDef } from "../ir/types.js";
+import { toTableVariableName } from "./naming.js";
 
 export function generateDescribe(tables: TableDef[], graph: RelationGraph): string {
   const lines: string[] = [];

--- a/src/generators/index-generator.ts
+++ b/src/generators/index-generator.ts
@@ -1,4 +1,4 @@
-import { quoted } from "../codegen/index.ts";
+import { quoted } from "../codegen/index.js";
 
 export function generateIndex(): string {
   const lines: string[] = [

--- a/src/generators/relations-generator.ts
+++ b/src/generators/relations-generator.ts
@@ -1,7 +1,7 @@
-import { importDecl, objectLiteral, RawCode } from "../codegen/index.ts";
-import type { Relation, RelationGraph } from "../ir/relation-graph.ts";
-import type { TableDef } from "../ir/types.ts";
-import { toTableVariableName } from "./naming.ts";
+import { importDecl, objectLiteral, RawCode } from "../codegen/index.js";
+import type { Relation, RelationGraph } from "../ir/relation-graph.js";
+import type { TableDef } from "../ir/types.js";
+import { toTableVariableName } from "./naming.js";
 
 export function generateRelations(tables: TableDef[], graph: RelationGraph): string {
   const lines: string[] = [];

--- a/src/generators/schema-generator.ts
+++ b/src/generators/schema-generator.ts
@@ -7,10 +7,10 @@ import {
   importDecl,
   objectLiteral,
   quoted,
-} from "../codegen/index.ts";
-import type { EnumDef, FieldDef, TableDef } from "../ir/types.ts";
-import { mapFieldToColumn } from "./column-mapper.ts";
-import { toTableVariableName } from "./naming.ts";
+} from "../codegen/index.js";
+import type { EnumDef, FieldDef, TableDef } from "../ir/types.js";
+import { mapFieldToColumn } from "./column-mapper.js";
+import { toTableVariableName } from "./naming.js";
 
 export function generateSchema(tables: TableDef[], enums: EnumDef[]): string {
   const sections: string[] = [];

--- a/src/generators/types-generator.ts
+++ b/src/generators/types-generator.ts
@@ -1,4 +1,4 @@
-import { exportConst, fnCall, importDecl, quoted } from "../codegen/index.ts";
+import { exportConst, fnCall, importDecl, quoted } from "../codegen/index.js";
 
 export function generateTypes(): string {
   const sections: string[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import type { EmitContext } from "@typespec/compiler";
 import { emitFile, resolvePath } from "@typespec/compiler";
-import { assemblePackage } from "./assembler.ts";
-import { buildIR } from "./ir/builder.ts";
+import { assemblePackage } from "./assembler.js";
+import { buildIR } from "./ir/builder.js";
 
 export {
   $check,
@@ -20,8 +20,8 @@ export {
   $updatedAt,
   $uuid,
   $visibility,
-} from "./decorators.ts";
-export { $lib } from "./lib.ts";
+} from "./decorators.js";
+export { $lib } from "./lib.js";
 
 export interface EmitterOptions {
   "package-name"?: string;

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -1,6 +1,6 @@
 import type { Model, ModelProperty, Scalar } from "@typespec/compiler";
-import { toSnakeCase } from "../generators/naming.ts";
-import { StateKeys } from "../lib.ts";
+import { toSnakeCase } from "../generators/naming.js";
+import { StateKeys } from "../lib.js";
 import type {
   EnumDef,
   FieldDef,
@@ -10,7 +10,7 @@ import type {
   TableDef,
   UniqueConstraintDef,
   UuidEncoding,
-} from "./types.ts";
+} from "./types.js";
 
 interface TableMeta {
   name: string;

--- a/src/ir/relation-graph.ts
+++ b/src/ir/relation-graph.ts
@@ -1,5 +1,5 @@
-import { toTableVariableName } from "../generators/naming.ts";
-import type { TableDef } from "./types.ts";
+import { toTableVariableName } from "../generators/naming.js";
+import type { TableDef } from "./types.js";
 
 /** A one-to-one or many-to-one relation (FK holder side) */
 export interface OneRelation {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,3 +1,6 @@
 {
-  "extends": "./tsconfig.json"
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
-    "allowImportingTsExtensions": true,
     "noEmit": true
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
## Summary
- Switch src/ imports from `.ts` to `.js` extensions so `tsgo` can emit compiled JS
- Update `tsconfig.build.json` to override `noEmit: false` for build
- Add `prepublishOnly` script and CI build step to ensure `dist/` exists before publish
- Switch test runner from `--experimental-strip-types` to `tsx` loader
- Update CI to Node 24 (matches local dev)

Closes #6

BREAKING CHANGE: Source imports changed from `.ts` to `.js` extensions.

## Test plan
- [x] `npm run check` passes
- [x] `npm run build` produces `dist/`
- [x] `npm test` — 274 tests pass
- [x] `npm run lint` clean
- [x] `npm pack --dry-run` shows `dist/` contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)