### PR TITLE
fix!: fix lib.js import, add babel deps, rename @visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
     "dist",
     "src/decorators.tsp"
   ],
+  "dependencies": {
+    "@babel/generator": "^7.29.1",
+    "@babel/parser": "^7.29.0",
+    "@babel/types": "^7.29.0"
+  },
   "peerDependencies": {
     "@typespec/compiler": ">=1.0.0"
   },
@@ -29,9 +34,6 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@babel/generator": "^7.29.1",
-    "@babel/parser": "^7.29.0",
-    "@babel/types": "^7.29.0",
     "@biomejs/biome": "^2.0.0",
     "@types/babel__generator": "^7.27.0",
     "@types/better-sqlite3": "^7.6.13",

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -113,6 +113,10 @@ export function $maxValue(context: DecoratorContext, target: ModelProperty, valu
   context.program.stateMap(StateKeys.maxValue).set(target, value);
 }
 
-export function $visibility(context: DecoratorContext, target: ModelProperty, value: string): void {
-  context.program.stateMap(StateKeys.visibility).set(target, value);
+export function $columnVisibility(
+  context: DecoratorContext,
+  target: ModelProperty,
+  value: string,
+): void {
+  context.program.stateMap(StateKeys.columnVisibility).set(target, value);
 }

--- a/src/decorators.tsp
+++ b/src/decorators.tsp
@@ -1,4 +1,4 @@
-import "./lib.js";
+import "../dist/lib.js";
 
 using TypeSpec.Reflection;
 
@@ -19,4 +19,4 @@ extern dec indexDef(target: Model, name: valueof string, columns: ModelProperty[
 extern dec foreignKeyDef(target: Model, name: valueof string, columns: ModelProperty[], foreignColumns: ModelProperty[]);
 extern dec minValue(target: ModelProperty, value: valueof int32);
 extern dec maxValue(target: ModelProperty, value: valueof int32);
-extern dec visibility(target: ModelProperty, value: valueof string);
+extern dec columnVisibility(target: ModelProperty, value: valueof string);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { buildIR } from "./ir/builder.js";
 
 export {
   $check,
+  $columnVisibility,
   $compositeUnique,
   $createdAt,
   $foreignKeyDef,
@@ -19,7 +20,6 @@ export {
   $unique,
   $updatedAt,
   $uuid,
-  $visibility,
 } from "./decorators.js";
 export { $lib } from "./lib.js";
 

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -94,7 +94,7 @@ export function buildIR(program: ProgramStateAccess): {
   const foreignKeyDefState = program.stateMap(StateKeys.foreignKeyDef);
   const minValueState = program.stateMap(StateKeys.minValue);
   const maxValueState = program.stateMap(StateKeys.maxValue);
-  const visibilityState = program.stateMap(StateKeys.visibility);
+  const visibilityState = program.stateMap(StateKeys.columnVisibility);
 
   for (const [target, meta] of tableState) {
     const model = target as Model;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -19,7 +19,7 @@ export const $lib = createTypeSpecLibrary({
     foreignKeyDef: { description: "State for @foreignKey decorator" },
     minValue: { description: "State for @minValue decorator" },
     maxValue: { description: "State for @maxValue decorator" },
-    visibility: { description: "State for @visibility decorator" },
+    columnVisibility: { description: "State for @columnVisibility decorator" },
   },
 } as const);
 

--- a/test/typespec/decorators.test.ts
+++ b/test/typespec/decorators.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import type { DecoratorContext, Model, ModelProperty } from "@typespec/compiler";
 import {
   $check,
+  $columnVisibility,
   $compositeUnique,
   $createdAt,
   $foreignKeyDef,
@@ -17,7 +18,6 @@ import {
   $unique,
   $updatedAt,
   $uuid,
-  $visibility,
 } from "../../src/decorators.ts";
 import { StateKeys } from "../../src/lib.ts";
 
@@ -413,17 +413,17 @@ describe("decorator functions", () => {
   });
 
   // ===========================================
-  // @visibility
+  // @columnVisibility
   // ===========================================
 
-  it("$visibility stores value in visibility state map", () => {
+  it("$columnVisibility stores value in columnVisibility state map", () => {
     const program = createMockProgram();
     const ctx = createMockContext(program);
     const prop = mockProp("createdAt");
 
-    $visibility(ctx, prop, "read");
+    $columnVisibility(ctx, prop, "read");
 
-    const stored = program.stateMap(StateKeys.visibility).get(prop);
+    const stored = program.stateMap(StateKeys.columnVisibility).get(prop);
     assert.equal(stored, "read");
   });
 });


### PR DESCRIPTION
## Summary
- Fix `src/decorators.tsp` importing `./lib.js` (should be `../dist/lib.js` since tspMain resolves relative to the .tsp file)
- Move `@babel/generator`, `@babel/parser`, `@babel/types` from devDependencies to dependencies (required at runtime)
- Rename `@visibility` decorator to `@columnVisibility` to avoid conflict with TypeSpec built-in `@visibility`

Closes #8

## Test plan
- [x] All 274 tests pass
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)