### PR TITLE
fix: import dist/index.js in tsp entrypoint for extern dec resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "typespec": "./tsp/main.tsp",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
-  "tspMain": "src/decorators.tsp",
   "files": [
     "dist",
-    "src/decorators.tsp"
+    "tsp"
   ],
   "dependencies": {
     "@babel/generator": "^7.29.1",

--- a/tsp/main.tsp
+++ b/tsp/main.tsp
@@ -1,4 +1,4 @@
-import "../dist/lib.js";
+import "../dist/index.js";
 
 using TypeSpec.Reflection;
 


### PR DESCRIPTION
## Summary

- Moves TypeSpec entrypoint from `src/decorators.tsp` to `tsp/main.tsp`, importing `../dist/index.js` instead of `../dist/lib.js`
- Replaces deprecated `tspMain` field with `exports["."].typespec` condition in `package.json`
- Updates `files` array to include `tsp/` directory

`dist/lib.js` only exports `$lib` and `StateKeys`. The 16 `$decorator` functions (`$table`, `$pk`, `$uuid`, etc.) are in `decorators.js` and re-exported through `index.js`. TypeSpec resolves `extern dec` by scanning exports of imported JS files, so importing `lib.js` caused all extern dec declarations to fail with `missing-implementation` errors.

Closes #11

## Test plan

- [x] `npm run build` succeeds
- [x] All 274 tests pass
- [x] `npm pack --dry-run` confirms `tsp/main.tsp` included, `src/decorators.tsp` excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)