### PR TITLE
feat: generate nullable customType wrappers for columns

### DIFF
--- a/src/generators/column-mapper.ts
+++ b/src/generators/column-mapper.ts
@@ -41,7 +41,8 @@ export function mapFieldToColumn(
     calls.push({ method: "default", args: [mapDefault(field.defaultValue)] });
   }
 
-  return chainCall(dialect.mapFieldType(field), calls);
+  const base = field.nullable ? dialect.mapNullableFieldType(field) : dialect.mapFieldType(field);
+  return chainCall(base, calls);
 }
 
 function isPrimaryKey(field: FieldDef, table: TableDef): boolean {

--- a/src/generators/dialect.ts
+++ b/src/generators/dialect.ts
@@ -1,8 +1,14 @@
 import type { ChainMethod } from "../codegen/index.js";
 import { arrayLiteral, fnCall, objectLiteral, quoted } from "../codegen/index.js";
-import type { FieldDef } from "../ir/types.js";
+import type { FieldDef, FieldType } from "../ir/types.js";
 
 export type Dialect = "pg" | "sqlite";
+
+export interface NullableWrapperDef {
+  name: string;
+  dataType: string;
+  jsType: string;
+}
 
 export interface DialectConfig {
   dialect: Dialect;
@@ -10,7 +16,10 @@ export interface DialectConfig {
   tableFn: string;
   enumFn: string | null;
   uuidDataType: string;
+  nullableWrappers: readonly NullableWrapperDef[];
   mapFieldType(field: FieldDef): string;
+  mapNullableFieldType(field: FieldDef): string;
+  nullableWrapperName(kind: FieldType["kind"]): string | null;
   mapTimestampDefault(): ChainMethod;
 }
 
@@ -23,6 +32,26 @@ export function resolveDialect(dialect: Dialect): DialectConfig {
   }
 }
 
+const pgNullableWrappers: readonly NullableWrapperDef[] = [
+  { name: "nullableText", dataType: "text", jsType: "string" },
+  { name: "nullableInteger", dataType: "integer", jsType: "number" },
+  { name: "nullableReal", dataType: "real", jsType: "number" },
+  { name: "nullableBigint", dataType: "bigint", jsType: "number" },
+  { name: "nullableDoublePrecision", dataType: "double precision", jsType: "number" },
+  { name: "nullableBoolean", dataType: "boolean", jsType: "boolean" },
+  { name: "nullableTimestamp", dataType: "timestamp with time zone", jsType: "Date" },
+];
+
+const pgNullableWrapperMap = new Map<string, string>([
+  ["text", "nullableText"],
+  ["integer", "nullableInteger"],
+  ["real", "nullableReal"],
+  ["bigint", "nullableBigint"],
+  ["doublePrecision", "nullableDoublePrecision"],
+  ["boolean", "nullableBoolean"],
+  ["timestamp", "nullableTimestamp"],
+]);
+
 function pgDialect(): DialectConfig {
   return {
     dialect: "pg",
@@ -30,7 +59,18 @@ function pgDialect(): DialectConfig {
     tableFn: "pgTable",
     enumFn: "pgEnum",
     uuidDataType: "uuid",
+    nullableWrappers: pgNullableWrappers,
     mapTimestampDefault: () => ({ method: "defaultNow" }),
+    nullableWrapperName(kind: FieldType["kind"]): string | null {
+      return pgNullableWrapperMap.get(kind) ?? null;
+    },
+    mapNullableFieldType(field: FieldDef): string {
+      const wrapperName = this.nullableWrapperName(field.type.kind);
+      if (wrapperName) {
+        return fnCall(wrapperName, [quoted(field.columnName)]);
+      }
+      return this.mapFieldType(field);
+    },
     mapFieldType(field: FieldDef): string {
       const col = quoted(field.columnName);
       switch (field.type.kind) {
@@ -68,6 +108,20 @@ function pgDialect(): DialectConfig {
   };
 }
 
+const sqliteNullableWrappers: readonly NullableWrapperDef[] = [
+  { name: "nullableText", dataType: "text", jsType: "string" },
+  { name: "nullableInteger", dataType: "integer", jsType: "number" },
+  { name: "nullableReal", dataType: "real", jsType: "number" },
+];
+
+const sqliteNullableWrapperMap = new Map<string, string>([
+  ["text", "nullableText"],
+  ["varchar", "nullableText"],
+  ["integer", "nullableInteger"],
+  ["real", "nullableReal"],
+  ["doublePrecision", "nullableReal"],
+]);
+
 function sqliteDialect(): DialectConfig {
   return {
     dialect: "sqlite",
@@ -75,7 +129,18 @@ function sqliteDialect(): DialectConfig {
     tableFn: "sqliteTable",
     enumFn: null,
     uuidDataType: "text",
+    nullableWrappers: sqliteNullableWrappers,
     mapTimestampDefault: () => ({ method: "$defaultFn", args: ["() => new Date()"] }),
+    nullableWrapperName(kind: FieldType["kind"]): string | null {
+      return sqliteNullableWrapperMap.get(kind) ?? null;
+    },
+    mapNullableFieldType(field: FieldDef): string {
+      const wrapperName = this.nullableWrapperName(field.type.kind);
+      if (wrapperName) {
+        return fnCall(wrapperName, [quoted(field.columnName)]);
+      }
+      return this.mapFieldType(field);
+    },
     mapFieldType(field: FieldDef): string {
       const col = quoted(field.columnName);
       switch (field.type.kind) {

--- a/src/generators/schema-generator.ts
+++ b/src/generators/schema-generator.ts
@@ -46,11 +46,8 @@ function generateImports(tables: TableDef[], enums: EnumDef[], dialect: DialectC
     lines.push(importDecl(["sql"], "drizzle-orm"));
   }
 
-  if (hasUuidFields(tables)) {
-    const typesImports = ["base36Uuid"];
-    if (hasAutoGenerateUuid(tables)) {
-      typesImports.push("generateBase36Id");
-    }
+  const typesImports = collectTypesImports(tables, dialect);
+  if (typesImports.length > 0) {
     lines.push(importDecl(typesImports, "./types.js"));
   }
 
@@ -104,6 +101,7 @@ function collectCoreImports(
 
     for (const field of table.fields) {
       if (field.uuid) continue;
+      if (field.nullable && dialect.nullableWrapperName(field.type.kind)) continue;
 
       for (const imp of collectFieldImports(field, dialect)) {
         imports.add(imp);
@@ -170,12 +168,27 @@ function hasCheckConstraints(table: TableDef): boolean {
   );
 }
 
-function hasUuidFields(tables: TableDef[]): boolean {
-  return tables.some((t) => t.fields.some((f) => f.uuid));
-}
+function collectTypesImports(tables: TableDef[], dialect: DialectConfig): string[] {
+  const imports = new Set<string>();
 
-function hasAutoGenerateUuid(tables: TableDef[]): boolean {
-  return tables.some((t) => t.fields.some((f) => f.uuid?.autoGenerate));
+  for (const table of tables) {
+    for (const field of table.fields) {
+      if (field.uuid) {
+        imports.add("base36Uuid");
+        if (field.uuid.autoGenerate) {
+          imports.add("generateBase36Id");
+        }
+      }
+      if (field.nullable && !field.uuid) {
+        const wrapperName = dialect.nullableWrapperName(field.type.kind);
+        if (wrapperName) {
+          imports.add(wrapperName);
+        }
+      }
+    }
+  }
+
+  return [...imports].sort();
 }
 
 function generateEnumDeclaration(enumDef: EnumDef, enumFn: string): string {

--- a/src/generators/types-generator.ts
+++ b/src/generators/types-generator.ts
@@ -1,5 +1,5 @@
 import { exportConst, fnCall, importDecl, quoted } from "../codegen/index.js";
-import type { DialectConfig } from "./dialect.js";
+import type { DialectConfig, NullableWrapperDef } from "./dialect.js";
 
 export function generateTypes(dialect: DialectConfig): string {
   const sections: string[] = [];
@@ -33,6 +33,11 @@ export function generateTypes(dialect: DialectConfig): string {
   sections.push("}");
   sections.push("");
 
+  for (const wrapper of dialect.nullableWrappers) {
+    sections.push(generateNullableWrapper(wrapper));
+    sections.push("");
+  }
+
   sections.push("/** Drizzle client type for use in describe function signatures */");
   sections.push(drizzleClientType(dialect));
   sections.push("");
@@ -51,6 +56,17 @@ function drizzleClientImports(dialect: DialectConfig): string[] {
     importDecl(["PgAsyncDatabase", "PgQueryResultHKT"], "drizzle-orm/pg-core", { type: true }),
     importDecl(["relations"], "./relations.js", { type: true }),
   ];
+}
+
+function generateNullableWrapper(wrapper: NullableWrapperDef): string {
+  const typeParam = `<{\n  data: ${wrapper.jsType} | undefined;\n  driverData: ${wrapper.jsType} | null;\n}>`;
+  const configObj = [
+    "{",
+    `  dataType: () => ${quoted(wrapper.dataType)},`,
+    `  fromDriver: (v) => v ?? undefined,`,
+    "}",
+  ].join("\n");
+  return exportConst(wrapper.name, `customType${typeParam}(${configObj})`);
 }
 
 function drizzleClientType(dialect: DialectConfig): string {

--- a/test/fixtures/bookstore-schema.ts
+++ b/test/fixtures/bookstore-schema.ts
@@ -1,4 +1,14 @@
-import { integer, primaryKey, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { customType, integer, primaryKey, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+const nullableText = customType<{ data: string | undefined; driverData: string | null }>({
+  dataType: () => "text",
+  fromDriver: (v) => v ?? undefined,
+});
+
+const nullableInteger = customType<{ data: number | undefined; driverData: number | null }>({
+  dataType: () => "integer",
+  fromDriver: (v) => v ?? undefined,
+});
 
 // ============================================
 // Author
@@ -7,9 +17,9 @@ import { integer, primaryKey, sqliteTable, text } from "drizzle-orm/sqlite-core"
 export const authors = sqliteTable("authors", {
   authorId: text("author_id").primaryKey(),
   name: text("name").notNull(),
-  bio: text("bio"),
-  birthYear: integer("birth_year"),
-  nationality: text("nationality"),
+  bio: nullableText("bio"),
+  birthYear: nullableInteger("birth_year"),
+  nationality: nullableText("nationality"),
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),
 });
@@ -26,8 +36,8 @@ export const books = sqliteTable("books", {
   title: text("title").notNull(),
   originalLanguage: text("original_language").notNull(),
   publicationYear: integer("publication_year").notNull(),
-  isbn: text("isbn"),
-  pageCount: integer("page_count"),
+  isbn: nullableText("isbn"),
+  pageCount: nullableInteger("page_count"),
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),
 });
@@ -39,7 +49,7 @@ export const books = sqliteTable("books", {
 export const genres = sqliteTable("genres", {
   genreId: text("genre_id").primaryKey(),
   name: text("name").notNull(),
-  description: text("description"),
+  description: nullableText("description"),
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),
 });
@@ -94,8 +104,8 @@ export const translators = sqliteTable("translators", {
 export const publishers = sqliteTable("publishers", {
   publisherId: text("publisher_id").primaryKey(),
   name: text("name").notNull(),
-  country: text("country"),
-  founded: integer("founded"),
+  country: nullableText("country"),
+  founded: nullableInteger("founded"),
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),
 });
@@ -116,7 +126,7 @@ export const editions = sqliteTable("editions", {
   format: text("format", { enum: ["hardcover", "paperback", "ebook", "audiobook"] }).notNull(),
   language: text("language").notNull(),
   title: text("title").notNull(),
-  isbn: text("isbn"),
+  isbn: nullableText("isbn"),
   publicationYear: integer("publication_year").notNull(),
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),
@@ -132,7 +142,7 @@ export const reviews = sqliteTable("reviews", {
     .notNull()
     .references(() => books.bookId),
   rating: integer("rating").notNull(),
-  text: text("text"),
+  text: nullableText("text"),
   reviewerName: text("reviewer_name").notNull(),
   reviewDate: text("review_date").notNull(),
   createdAt: text("created_at").notNull(),

--- a/test/generators/column-mapper.test.ts
+++ b/test/generators/column-mapper.test.ts
@@ -55,7 +55,7 @@ describe("column mapper", () => {
     assert.equal(mapFieldToColumn(field, table, pg), 'text("title").notNull()');
   });
 
-  it("maps an optional text field (nullable)", () => {
+  it("maps an optional text field (nullable) to nullableText", () => {
     const field = makeField({
       name: "bio",
       columnName: "bio",
@@ -63,7 +63,7 @@ describe("column mapper", () => {
       nullable: true,
     });
     const table = makeTable(["id"]);
-    assert.equal(mapFieldToColumn(field, table, pg), 'text("bio")');
+    assert.equal(mapFieldToColumn(field, table, pg), 'nullableText("bio")');
   });
 
   it("maps a required integer field", () => {
@@ -77,7 +77,7 @@ describe("column mapper", () => {
     assert.equal(mapFieldToColumn(field, table, pg), 'integer("publication_year").notNull()');
   });
 
-  it("maps an optional integer field", () => {
+  it("maps an optional integer field to nullableInteger", () => {
     const field = makeField({
       name: "pageCount",
       columnName: "page_count",
@@ -85,7 +85,7 @@ describe("column mapper", () => {
       nullable: true,
     });
     const table = makeTable(["id"]);
-    assert.equal(mapFieldToColumn(field, table, pg), 'integer("page_count")');
+    assert.equal(mapFieldToColumn(field, table, pg), 'nullableInteger("page_count")');
   });
 
   it("maps a varchar field", () => {
@@ -427,6 +427,61 @@ describe("column mapper (sqlite)", () => {
       mapFieldToColumn(field, table, sqlite),
       'text("status", { enum: ["draft", "published"] }).notNull().default("draft")',
     );
+  });
+
+  it("maps nullable text field to nullableText", () => {
+    const field = makeField({
+      name: "bio",
+      columnName: "bio",
+      type: { kind: "text" },
+      nullable: true,
+    });
+    const table = makeTable(["id"]);
+    assert.equal(mapFieldToColumn(field, table, sqlite), 'nullableText("bio")');
+  });
+
+  it("maps nullable integer field to nullableInteger", () => {
+    const field = makeField({
+      name: "pageCount",
+      columnName: "page_count",
+      type: { kind: "integer" },
+      nullable: true,
+    });
+    const table = makeTable(["id"]);
+    assert.equal(mapFieldToColumn(field, table, sqlite), 'nullableInteger("page_count")');
+  });
+
+  it("maps nullable real field to nullableReal", () => {
+    const field = makeField({
+      name: "score",
+      columnName: "score",
+      type: { kind: "real" },
+      nullable: true,
+    });
+    const table = makeTable(["id"]);
+    assert.equal(mapFieldToColumn(field, table, sqlite), 'nullableReal("score")');
+  });
+
+  it("maps nullable varchar to nullableText in SQLite", () => {
+    const field = makeField({
+      name: "name",
+      columnName: "name",
+      type: { kind: "varchar", length: 256 },
+      nullable: true,
+    });
+    const table = makeTable(["id"]);
+    assert.equal(mapFieldToColumn(field, table, sqlite), 'nullableText("name")');
+  });
+
+  it("maps nullable doublePrecision to nullableReal in SQLite", () => {
+    const field = makeField({
+      name: "price",
+      columnName: "price",
+      type: { kind: "doublePrecision" },
+      nullable: true,
+    });
+    const table = makeTable(["id"]);
+    assert.equal(mapFieldToColumn(field, table, sqlite), 'nullableReal("price")');
   });
 
   it("maps uuid field to base36Uuid", () => {

--- a/test/generators/schema.test.ts
+++ b/test/generators/schema.test.ts
@@ -13,7 +13,11 @@ describe("schema generator", () => {
     const output = generateSchema(bookstoreTables, bookstoreEnums, pg);
 
     assert.ok(output.includes('from "drizzle-orm/pg-core"'));
-    assert.ok(output.includes('import { base36Uuid, generateBase36Id } from "./types.js"'));
+    assert.ok(output.includes('from "./types.js"'));
+    assert.ok(output.includes("base36Uuid"));
+    assert.ok(output.includes("generateBase36Id"));
+    assert.ok(output.includes("nullableInteger"));
+    assert.ok(output.includes("nullableText"));
     assert.ok(output.includes("pgTable,"));
     assert.ok(output.includes("integer,"));
     assert.ok(output.includes("text,"));
@@ -63,9 +67,9 @@ describe("schema generator", () => {
       ),
     );
     assert.ok(output.includes('name: text("name").notNull(),'));
-    assert.ok(output.includes('bio: text("bio"),'));
-    assert.ok(output.includes('birthYear: integer("birth_year"),'));
-    assert.ok(output.includes('nationality: text("nationality"),'));
+    assert.ok(output.includes('bio: nullableText("bio"),'));
+    assert.ok(output.includes('birthYear: nullableInteger("birth_year"),'));
+    assert.ok(output.includes('nationality: nullableText("nationality"),'));
     assert.ok(
       output.includes(
         'createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),',
@@ -98,8 +102,8 @@ describe("schema generator", () => {
     assert.ok(output.includes('originalLanguage: text("original_language").notNull(),'));
     assert.ok(output.includes('publicationYear: integer("publication_year").notNull(),'));
     // isbn has .unique()
-    assert.ok(output.includes('isbn: text("isbn").unique(),'));
-    assert.ok(output.includes('pageCount: integer("page_count"),'));
+    assert.ok(output.includes('isbn: nullableText("isbn").unique(),'));
+    assert.ok(output.includes('pageCount: nullableInteger("page_count"),'));
     // Index in callback
     assert.ok(
       output.includes(
@@ -117,7 +121,7 @@ describe("schema generator", () => {
         'genreId: base36Uuid("genre_id").primaryKey().$defaultFn(() => generateBase36Id()),',
       ),
     );
-    assert.ok(output.includes('description: text("description"),'));
+    assert.ok(output.includes('description: nullableText("description"),'));
   });
 
   it("generates bookGenres junction table with composite PK", () => {
@@ -174,8 +178,8 @@ describe("schema generator", () => {
         'publisherId: base36Uuid("publisher_id").primaryKey().$defaultFn(() => generateBase36Id()),',
       ),
     );
-    assert.ok(output.includes('country: text("country"),'));
-    assert.ok(output.includes('founded: integer("founded"),'));
+    assert.ok(output.includes('country: nullableText("country"),'));
+    assert.ok(output.includes('founded: nullableInteger("founded"),'));
   });
 
   it("generates editions table with FKs, enum field, and composite unique", () => {
@@ -206,7 +210,7 @@ describe("schema generator", () => {
     // Enum field
     assert.ok(output.includes('format: bookFormatEnum("format").notNull(),'));
     assert.ok(output.includes('language: text("language").notNull(),'));
-    assert.ok(output.includes('isbn: text("isbn"),'));
+    assert.ok(output.includes('isbn: nullableText("isbn"),'));
     assert.ok(output.includes('publicationYear: integer("publication_year").notNull(),'));
     // Composite unique constraint
     assert.ok(
@@ -229,7 +233,7 @@ describe("schema generator", () => {
       output.includes('bookId: base36Uuid("book_id").notNull().references(() => books.bookId),'),
     );
     assert.ok(output.includes('rating: integer("rating").notNull(),'));
-    assert.ok(output.includes('text: text("text"),'));
+    assert.ok(output.includes('text: nullableText("text"),'));
     assert.ok(output.includes('reviewerName: text("reviewer_name").notNull(),'));
     assert.ok(
       output.includes('reviewDate: timestamp("review_date", { withTimezone: true }).notNull(),'),

--- a/test/generators/types.test.ts
+++ b/test/generators/types.test.ts
@@ -60,6 +60,35 @@ describe("types generator", () => {
     assert.ok(typesOutput.includes("export function generateBase36Id(): string {"));
     assert.ok(typesOutput.includes("return translator.new();"));
   });
+
+  it("exports nullableText custom type", () => {
+    assert.ok(typesOutput.includes("export const nullableText = customType<{"));
+    assert.ok(typesOutput.includes("  data: string | undefined;"));
+    assert.ok(typesOutput.includes("  driverData: string | null;"));
+    assert.ok(typesOutput.includes('dataType: () => "text",'));
+    assert.ok(typesOutput.includes("fromDriver: (v) => v ?? undefined,"));
+  });
+
+  it("exports nullableInteger custom type", () => {
+    assert.ok(typesOutput.includes("export const nullableInteger = customType<{"));
+    assert.ok(typesOutput.includes('dataType: () => "integer",'));
+  });
+
+  it("exports nullableReal custom type", () => {
+    assert.ok(typesOutput.includes("export const nullableReal = customType<{"));
+    assert.ok(typesOutput.includes('dataType: () => "real",'));
+  });
+
+  it("exports PG-specific nullable wrappers", () => {
+    assert.ok(typesOutput.includes("export const nullableBigint = customType<{"));
+    assert.ok(typesOutput.includes("export const nullableDoublePrecision = customType<{"));
+    assert.ok(typesOutput.includes("export const nullableBoolean = customType<{"));
+    assert.ok(typesOutput.includes("export const nullableTimestamp = customType<{"));
+  });
+
+  it("nullableTimestamp uses timestamp with time zone dataType", () => {
+    assert.ok(typesOutput.includes('dataType: () => "timestamp with time zone",'));
+  });
 });
 
 describe("index generator", () => {
@@ -112,5 +141,27 @@ describe("types generator (sqlite)", () => {
 
   it("exports generateBase36Id function", () => {
     assert.ok(output.includes("export function generateBase36Id(): string {"));
+  });
+
+  it("exports nullableText custom type for SQLite", () => {
+    assert.ok(output.includes("export const nullableText = customType<{"));
+    assert.ok(output.includes('dataType: () => "text",'));
+  });
+
+  it("exports nullableInteger custom type for SQLite", () => {
+    assert.ok(output.includes("export const nullableInteger = customType<{"));
+    assert.ok(output.includes('dataType: () => "integer",'));
+  });
+
+  it("exports nullableReal custom type for SQLite", () => {
+    assert.ok(output.includes("export const nullableReal = customType<{"));
+    assert.ok(output.includes('dataType: () => "real",'));
+  });
+
+  it("does not export PG-specific nullable wrappers", () => {
+    assert.ok(!output.includes("nullableBigint"));
+    assert.ok(!output.includes("nullableDoublePrecision"));
+    assert.ok(!output.includes("nullableBoolean"));
+    assert.ok(!output.includes("nullableTimestamp"));
   });
 });

--- a/test/integration/assembly.test.ts
+++ b/test/integration/assembly.test.ts
@@ -143,10 +143,14 @@ describe("package assembly", () => {
     assert.ok(schema.includes('from "drizzle-orm/pg-core"'));
   });
 
-  it("schema.ts imports base36Uuid and generateBase36Id from types", () => {
+  it("schema.ts imports base36Uuid, generateBase36Id, and nullable wrappers from types", () => {
     const schema = files.get("schema.ts");
     assert.ok(schema);
-    assert.ok(schema.includes('import { base36Uuid, generateBase36Id } from "./types.js"'));
+    assert.ok(schema.includes('from "./types.js"'));
+    assert.ok(schema.includes("base36Uuid"));
+    assert.ok(schema.includes("generateBase36Id"));
+    assert.ok(schema.includes("nullableInteger"));
+    assert.ok(schema.includes("nullableText"));
   });
 
   // ===========================================


### PR DESCRIPTION
## Summary

- Generate `customType` wrappers (`nullableText`, `nullableInteger`, `nullableReal`) for nullable columns that convert `null` → `undefined` via `fromDriver: (v) => v ?? undefined`
- SQLite gets 3 wrappers (text, integer, real); PG gets 7 (adds bigint, doublePrecision, boolean, timestamp)
- Column mapper uses `dialect.mapNullableFieldType()` for nullable fields, falling back to standard mapping for enums/uuids

## Test plan

- [x] 329 tests pass (14 new) — types, column-mapper, schema, assembly, integration
- [x] `npm run fix` clean
- [x] Integration tests with real SQLite still pass (constraint enforcement, describe queries, relations)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)