### PR TITLE
feat: remit entity front-end and real-world model fidelity

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,10 @@ model Author {
   @uuid("base36", true)           // UUID with base36 encoding, auto-generated
   authorId: string;
 
-  @references(Author.authorId)    // foreign key to another entity
+  @references(Author.authorId)             // foreign key to another entity
+  authorId: string;
+
+  @references(Author.authorId, "CASCADE")  // foreign key with ON DELETE policy
   authorId: string;
 
   @junction                       // on model: marks as many-to-many junction table
@@ -304,6 +307,23 @@ When using `sqlite`, types that don't exist natively in SQLite are mapped to com
 | `int64`       | `bigint({ mode: "number" })`        | `integer({ mode: "number" })`           |
 | `string` (with length) | `varchar({ length })`     | `text({ length })`                      |
 | TypeSpec `enum` | `pgEnum()`                        | `text()` (no native enums in SQLite)    |
+
+## Front-end option
+
+Set `frontend` in your `tspconfig.yaml` to choose which TypeSpec vocabulary the emitter reads. Defaults to `drizzle`.
+
+| Value     | Reads                                                                 |
+| --------- | -------------------------------------------------------------------- |
+| `drizzle` | This library's own `@table` / `@pk` / `@references` decorators.       |
+| `remit`   | The ElectroDB vocabulary (`@entity` / `@index`) from `typespec-electrodb-emitter`. |
+
+The `remit` front-end maps an ElectroDB model to a table: the primary `@index` becomes the primary key (composite when it has both `pk` and `sk`), each secondary `@index` becomes a named index, and a `collection` shared by two or more entities becomes an `ON DELETE CASCADE` foreign key from each member to the entity that owns the shared partition key.
+
+```yaml
+options:
+  "@kattebak/typespec-drizzle-orm-generator":
+    frontend: "remit"
+```
 
 ## Type mapping (PostgreSQL)
 

--- a/README.md
+++ b/README.md
@@ -317,23 +317,29 @@ Set `frontend` in your `tspconfig.yaml` to choose which TypeSpec vocabulary the 
 | `drizzle` | This library's own `@table` / `@pk` / `@references` decorators.       |
 | `remit`   | The ElectroDB vocabulary (`@entity` / `@index`) from `typespec-electrodb-emitter`. |
 
-The `remit` front-end maps an ElectroDB model to a table: the primary `@index` becomes the primary key (composite when it has both `pk` and `sk`), each secondary `@index` becomes a named index, and a `collection` shared by two or more entities becomes an `ON DELETE CASCADE` foreign key from each member to the entity that owns the shared partition key.
+The `remit` front-end maps an ElectroDB model to a table:
+
+- **Primary key** is the entity's own identity field, `<entity>Id`, as a single column. The ElectroDB primary index is a DynamoDB access pattern, not the entity's identity, so it becomes an ordinary secondary index. An entity with no `<entity>Id` field keeps the ElectroDB primary composite as its key.
+- Every `@index` becomes a named secondary index.
+- **Enums** are text columns narrowed by a `$type` union, not pgEnums — a store that mirrors a DynamoDB port keeps enum values as strings and avoids an `ALTER TYPE` per new value.
+- A `collection` shared by two or more entities becomes an `ON DELETE CASCADE` foreign key from each member to the entity that owns the shared partition key (unless `foreign-keys: false`).
 
 ```yaml
 options:
   "@kattebak/typespec-drizzle-orm-generator":
     frontend: "remit"
+    schema-only: true
+    foreign-keys: false
+    id-default: true
 ```
 
 ## Schema-only output
 
 `relations.ts`, `describe.ts`, and the `DrizzleClient` type use the Drizzle v2 relational API (`defineRelations`, `PgAsyncDatabase`). Set `schema-only: true` to emit just the table schema (`schema.ts` + the `base36Uuid` / nullable custom types), which stays compatible with Drizzle v1 consumers that manage relations themselves. The generated `package.json` then declares a `drizzle-orm` peer range of `>=0.30.0`.
 
-```yaml
-options:
-  "@kattebak/typespec-drizzle-orm-generator":
-    schema-only: true
-```
+## Foreign keys and id defaults
+
+`foreign-keys: false` drops the collection-derived foreign keys for a consumer that manages referential integrity and delete cascades in the application (a database `ON DELETE CASCADE` would otherwise fight an app-managed cascade). `id-default: true` attaches `.$defaultFn(() => generateBase36Id())` to single-column text primary keys so a caller may omit the id. Both are honoured by the `remit` front-end.
 
 ## Type mapping (PostgreSQL)
 

--- a/README.md
+++ b/README.md
@@ -325,6 +325,16 @@ options:
     frontend: "remit"
 ```
 
+## Schema-only output
+
+`relations.ts`, `describe.ts`, and the `DrizzleClient` type use the Drizzle v2 relational API (`defineRelations`, `PgAsyncDatabase`). Set `schema-only: true` to emit just the table schema (`schema.ts` + the `base36Uuid` / nullable custom types), which stays compatible with Drizzle v1 consumers that manage relations themselves. The generated `package.json` then declares a `drizzle-orm` peer range of `>=0.30.0`.
+
+```yaml
+options:
+  "@kattebak/typespec-drizzle-orm-generator":
+    schema-only: true
+```
+
 ## Type mapping (PostgreSQL)
 
 | TypeSpec               | Drizzle                             | PostgreSQL                |

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -13,6 +13,7 @@ export interface EmitterConfig {
   packageVersion: string;
   dialect: Dialect;
   pluralize: boolean;
+  schemaOnly?: boolean;
 }
 
 /**
@@ -28,16 +29,22 @@ export function assemblePackage(
 ): Map<string, string> {
   const graph = buildRelationGraph(tables, config.pluralize);
   const dialect = resolveDialect(config.dialect);
+  const schemaOnly = config.schemaOnly ?? false;
 
-  return new Map([
+  const files = new Map([
     ["package.json", generatePackageJson(config)],
     ["tsconfig.json", generateTsConfig()],
-    ["types.ts", generateTypes(dialect)],
+    ["types.ts", generateTypes(dialect, schemaOnly)],
     ["schema.ts", generateSchema(tables, enums, dialect, config.pluralize)],
-    ["relations.ts", generateRelations(tables, graph, config.pluralize)],
-    ["describe.ts", generateDescribe(tables, graph, config.pluralize)],
-    ["index.ts", generateIndex()],
+    ["index.ts", generateIndex(schemaOnly)],
   ]);
+
+  if (!schemaOnly) {
+    files.set("relations.ts", generateRelations(tables, graph, config.pluralize));
+    files.set("describe.ts", generateDescribe(tables, graph, config.pluralize));
+  }
+
+  return files;
 }
 
 function generatePackageJson(config: EmitterConfig): string {
@@ -61,7 +68,7 @@ function generatePackageJson(config: EmitterConfig): string {
       "short-uuid": "^5.2.0",
     },
     peerDependencies: {
-      "drizzle-orm": ">=1.0.0-beta.1",
+      "drizzle-orm": config.schemaOnly ? ">=0.30.0" : ">=1.0.0-beta.1",
       typescript: ">=5.0.0",
     },
   };

--- a/src/codegen/ast-helpers.ts
+++ b/src/codegen/ast-helpers.ts
@@ -12,7 +12,7 @@ function isObjectExpression(node: unknown): node is ObjectExpression {
 }
 
 export function quoted(value: string): string {
-  return `"${value}"`;
+  return JSON.stringify(value);
 }
 
 export function fnCall(name: string, args: string[]): string {

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -22,8 +22,9 @@ export function $references(
   context: DecoratorContext,
   target: ModelProperty,
   ref: ModelProperty,
+  onDelete?: "CASCADE" | "RESTRICT",
 ): void {
-  context.program.stateMap(StateKeys.references).set(target, ref);
+  context.program.stateMap(StateKeys.references).set(target, { ref, onDelete });
 }
 
 export function $junction(context: DecoratorContext, target: Model): void {

--- a/src/generators/column-mapper.ts
+++ b/src/generators/column-mapper.ts
@@ -1,4 +1,4 @@
-import { type ChainMethod, chainCall, quoted } from "../codegen/index.js";
+import { type ChainMethod, chainCall, objectLiteral, quoted } from "../codegen/index.js";
 import type { FieldDef, TableDef } from "../ir/types.js";
 import type { DialectConfig } from "./dialect.js";
 import { toTableVariableName } from "./naming.js";
@@ -26,7 +26,13 @@ export function mapFieldToColumn(
   if (field.references) {
     const targetVar = toTableVariableName(field.references.tableName, shouldPluralize);
     const targetField = field.references.fieldName;
-    calls.push({ method: "references", args: [`() => ${targetVar}.${targetField}`] });
+    const refArgs = [`() => ${targetVar}.${targetField}`];
+    if (field.references.onDelete) {
+      refArgs.push(
+        objectLiteral([["onDelete", quoted(field.references.onDelete)]], { concise: true }),
+      );
+    }
+    calls.push({ method: "references", args: refArgs });
   }
 
   if (field.createdAt || field.updatedAt) {

--- a/src/generators/column-mapper.ts
+++ b/src/generators/column-mapper.ts
@@ -15,7 +15,7 @@ export function mapFieldToColumn(
     calls.push({ method: "primaryKey" });
   }
 
-  if (field.uuid?.autoGenerate) {
+  if (field.uuid?.autoGenerate || field.autoGenerateId) {
     calls.push({ method: "$defaultFn", args: ["() => generateBase36Id()"] });
   }
 

--- a/src/generators/describe-generator.ts
+++ b/src/generators/describe-generator.ts
@@ -33,18 +33,20 @@ function generateDescribeBlock(
 ): string[] {
   const lines: string[] = [];
   const tableVar = toTableVariableName(table.name, shouldPluralize);
-  const pkField = table.primaryKey.columns[0];
+  const pkFields = table.primaryKey.isComposite
+    ? table.primaryKey.columns
+    : [table.primaryKey.columns[0]];
   const funcName = `describe${table.name}`;
   const typeName = `${table.name}Description`;
+  const whereClause = `{ ${pkFields.join(", ")} }`;
 
   lines.push(...generateDescriptionType(table, relations, typeName, tableVar, shouldPluralize));
 
-  lines.push(
-    `export const ${funcName} = (`,
-    `  db: DrizzleClient,`,
-    `  ${pkField}: string,`,
-    `): Promise<${typeName} | undefined> =>`,
-  );
+  lines.push(`export const ${funcName} = (`, `  db: DrizzleClient,`);
+  for (const pkField of pkFields) {
+    lines.push(`  ${pkField}: string,`);
+  }
+  lines.push(`): Promise<${typeName} | undefined> =>`);
 
   if (relations.length > 0) {
     const withObj = objectLiteral(
@@ -53,12 +55,12 @@ function generateDescribeBlock(
     );
     lines.push(
       `  db.query.${tableVar}.findFirst({`,
-      `    where: { ${pkField} },`,
+      `    where: ${whereClause},`,
       `    with: ${withObj},`,
       "  });",
     );
   } else {
-    lines.push(`  db.query.${tableVar}.findFirst({`, `    where: { ${pkField} },`, "  });");
+    lines.push(`  db.query.${tableVar}.findFirst({`, `    where: ${whereClause},`, "  });");
   }
 
   return lines;

--- a/src/generators/dialect.ts
+++ b/src/generators/dialect.ts
@@ -52,6 +52,11 @@ const pgNullableWrapperMap = new Map<string, string>([
   ["timestamp", "nullableTimestamp"],
 ]);
 
+function textEnumColumn(col: string, values: string[]): string {
+  const union = values.map((v) => quoted(v)).join(" | ");
+  return `${fnCall("text", [col])}.$type<${union}>()`;
+}
+
 function pgDialect(): DialectConfig {
   return {
     dialect: "pg",
@@ -105,6 +110,8 @@ function pgDialect(): DialectConfig {
           return fnCall("base36Uuid", [col]);
         case "enum":
           return fnCall(field.type.enumName, [col]);
+        case "textEnum":
+          return textEnumColumn(col, field.type.values);
       }
     },
   };
@@ -188,6 +195,8 @@ function sqliteDialect(): DialectConfig {
               concise: true,
             }),
           ]);
+        case "textEnum":
+          return textEnumColumn(col, field.type.values);
       }
     },
   };

--- a/src/generators/dialect.ts
+++ b/src/generators/dialect.ts
@@ -99,6 +99,8 @@ function pgDialect(): DialectConfig {
             col,
             objectLiteral([["withTimezone", "true"]], { concise: true }),
           ]);
+        case "jsonb":
+          return fnCall("jsonb", [col]);
         case "uuid":
           return fnCall("base36Uuid", [col]);
         case "enum":
@@ -171,6 +173,11 @@ function sqliteDialect(): DialectConfig {
           return fnCall("integer", [
             col,
             objectLiteral([["mode", quoted("timestamp")]], { concise: true }),
+          ]);
+        case "jsonb":
+          return fnCall("text", [
+            col,
+            objectLiteral([["mode", quoted("json")]], { concise: true }),
           ]);
         case "uuid":
           return fnCall("base36Uuid", [col]);

--- a/src/generators/index-generator.ts
+++ b/src/generators/index-generator.ts
@@ -1,13 +1,17 @@
 import { quoted } from "../codegen/index.js";
 
-export function generateIndex(): string {
+export function generateIndex(schemaOnly = false): string {
   const lines: string[] = [
     `export * from ${quoted("./types.js")};`,
     `export * from ${quoted("./schema.js")};`,
-    `export { relations } from ${quoted("./relations.js")};`,
-    `export * from ${quoted("./describe.js")};`,
-    "",
   ];
+
+  if (!schemaOnly) {
+    lines.push(`export { relations } from ${quoted("./relations.js")};`);
+    lines.push(`export * from ${quoted("./describe.js")};`);
+  }
+
+  lines.push("");
 
   return lines.join("\n");
 }

--- a/src/generators/schema-generator.ts
+++ b/src/generators/schema-generator.ts
@@ -122,6 +122,7 @@ function collectFieldImports(field: FieldDef, dialect: DialectConfig): string[] 
       case "text":
       case "varchar":
       case "enum":
+      case "jsonb":
         return ["text"];
       case "integer":
       case "bigint":
@@ -153,6 +154,8 @@ function collectFieldImports(field: FieldDef, dialect: DialectConfig): string[] 
       return ["boolean"];
     case "timestamp":
       return ["timestamp"];
+    case "jsonb":
+      return ["jsonb"];
     case "uuid":
     case "enum":
       return [];

--- a/src/generators/schema-generator.ts
+++ b/src/generators/schema-generator.ts
@@ -122,6 +122,7 @@ function collectFieldImports(field: FieldDef, dialect: DialectConfig): string[] 
       case "text":
       case "varchar":
       case "enum":
+      case "textEnum":
       case "jsonb":
         return ["text"];
       case "integer":
@@ -156,6 +157,8 @@ function collectFieldImports(field: FieldDef, dialect: DialectConfig): string[] 
       return ["timestamp"];
     case "jsonb":
       return ["jsonb"];
+    case "textEnum":
+      return ["text"];
     case "uuid":
     case "enum":
       return [];
@@ -181,6 +184,9 @@ function collectTypesImports(tables: TableDef[], dialect: DialectConfig): string
         if (field.uuid.autoGenerate) {
           imports.add("generateBase36Id");
         }
+      }
+      if (field.autoGenerateId) {
+        imports.add("generateBase36Id");
       }
       if (field.nullable && !field.uuid) {
         const wrapperName = dialect.nullableWrapperName(field.type.kind);

--- a/src/generators/types-generator.ts
+++ b/src/generators/types-generator.ts
@@ -1,12 +1,12 @@
 import { exportConst, fnCall, importDecl, quoted } from "../codegen/index.js";
 import type { DialectConfig, NullableWrapperDef } from "./dialect.js";
 
-export function generateTypes(dialect: DialectConfig): string {
+export function generateTypes(dialect: DialectConfig, schemaOnly = false): string {
   const sections: string[] = [];
 
   sections.push(importDecl(["customType"], dialect.coreModule));
   sections.push(`import short from ${quoted("short-uuid")};`);
-  sections.push(...drizzleClientImports(dialect));
+  if (!schemaOnly) sections.push(...drizzleClientImports(dialect));
   sections.push("");
 
   sections.push(`const translator = ${fnCall("short", ["short.constants.uuid25Base36"])};`);
@@ -38,9 +38,11 @@ export function generateTypes(dialect: DialectConfig): string {
     sections.push("");
   }
 
-  sections.push("/** Drizzle client type for use in describe function signatures */");
-  sections.push(drizzleClientType(dialect));
-  sections.push("");
+  if (!schemaOnly) {
+    sections.push("/** Drizzle client type for use in describe function signatures */");
+    sections.push(drizzleClientType(dialect));
+    sections.push("");
+  }
 
   return sections.join("\n");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,13 +44,32 @@ export interface EmitterOptions {
    * themselves. Defaults to false.
    */
   "schema-only"?: boolean;
+  /**
+   * How enum-typed properties become columns.
+   * - "native" (default): a Postgres `pgEnum` (a `CREATE TYPE` + typed column).
+   * - "text": a plain `text` column. Use when the target stores enums as strings
+   *   (e.g. matching a DynamoDB single-table port) and you want no `ALTER TYPE`
+   *   migrations. Currently honoured by the `remit` front-end.
+   */
+  "enum-mode"?: "native" | "text";
+  /**
+   * Emit foreign-key `references()` clauses. Defaults to true. Set false when the
+   * consumer manages referential integrity and delete cascades itself (so a
+   * database-level `ON DELETE CASCADE` would fight the application). In the remit
+   * front-end this drops the collection-derived foreign keys.
+   */
+  "foreign-keys"?: boolean;
 }
 
 export async function $onEmit(context: EmitContext<EmitterOptions>): Promise<void> {
   if (context.program.compilerOptions.noEmit) return;
 
+  const enumAsText = context.options["enum-mode"] === "text";
+  const foreignKeys = context.options["foreign-keys"] ?? true;
   const { tables, enums } =
-    context.options.frontend === "remit" ? buildRemitIR(context.program) : buildIR(context.program);
+    context.options.frontend === "remit"
+      ? buildRemitIR(context.program, { enumAsText, foreignKeys })
+      : buildIR(context.program);
 
   const config = {
     packageName: context.options["package-name"] ?? "drizzle-schema",

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,6 @@ export interface EmitterOptions {
    *   (e.g. matching a DynamoDB single-table port) and you want no `ALTER TYPE`
    *   migrations. Currently honoured by the `remit` front-end.
    */
-  "enum-mode"?: "native" | "text";
   /**
    * Emit foreign-key `references()` clauses. Defaults to true. Set false when the
    * consumer manages referential integrity and delete cascades itself (so a
@@ -59,16 +58,22 @@ export interface EmitterOptions {
    * front-end this drops the collection-derived foreign keys.
    */
   "foreign-keys"?: boolean;
+  /**
+   * Attach `.$defaultFn(() => generateBase36Id())` to single-column text primary
+   * keys so a caller may omit the id. Defaults to false. Honoured by the remit
+   * front-end. Enable when the store generates its own base36 ids.
+   */
+  "id-default"?: boolean;
 }
 
 export async function $onEmit(context: EmitContext<EmitterOptions>): Promise<void> {
   if (context.program.compilerOptions.noEmit) return;
 
-  const enumAsText = context.options["enum-mode"] === "text";
   const foreignKeys = context.options["foreign-keys"] ?? true;
+  const idDefault = context.options["id-default"] ?? false;
   const { tables, enums } =
     context.options.frontend === "remit"
-      ? buildRemitIR(context.program, { enumAsText, foreignKeys })
+      ? buildRemitIR(context.program, { foreignKeys, idDefault })
       : buildIR(context.program);
 
   const config = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,14 @@ export interface EmitterOptions {
    * - "remit": the ElectroDB vocabulary (`@entity`/`@index`) via `buildRemitIR`.
    */
   frontend?: "drizzle" | "remit";
+  /**
+   * When true, emit only the table schema (`schema.ts` + `types.ts`) and omit
+   * `relations.ts` / `describe.ts`. The relations and describe helpers use the
+   * Drizzle v2 relational API (`defineRelations`, `PgAsyncDatabase`); schema-only
+   * output stays compatible with Drizzle v1 consumers that manage relations
+   * themselves. Defaults to false.
+   */
+  "schema-only"?: boolean;
 }
 
 export async function $onEmit(context: EmitContext<EmitterOptions>): Promise<void> {
@@ -49,6 +57,7 @@ export async function $onEmit(context: EmitContext<EmitterOptions>): Promise<voi
     packageVersion: context.options["package-version"] ?? "0.0.1",
     dialect: context.options.dialect ?? "pg",
     pluralize: context.options.pluralize ?? true,
+    schemaOnly: context.options["schema-only"] ?? false,
   };
 
   const files = assemblePackage(tables, enums, config);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { emitFile, resolvePath } from "@typespec/compiler";
 import { assemblePackage } from "./assembler.js";
 import type { Dialect } from "./generators/dialect.js";
 import { buildIR } from "./ir/builder.js";
+import { buildRemitIR } from "./ir/remit-builder.js";
 
 export {
   $check,
@@ -29,12 +30,19 @@ export interface EmitterOptions {
   "package-version"?: string;
   dialect?: Dialect;
   pluralize?: boolean;
+  /**
+   * Selects the front-end that reads the TypeSpec vocabulary.
+   * - "drizzle" (default): this library's own `@table`/`@pk`/`@references` decorators.
+   * - "remit": the ElectroDB vocabulary (`@entity`/`@index`) via `buildRemitIR`.
+   */
+  frontend?: "drizzle" | "remit";
 }
 
 export async function $onEmit(context: EmitContext<EmitterOptions>): Promise<void> {
   if (context.program.compilerOptions.noEmit) return;
 
-  const { tables, enums } = buildIR(context.program);
+  const { tables, enums } =
+    context.options.frontend === "remit" ? buildRemitIR(context.program) : buildIR(context.program);
 
   const config = {
     packageName: context.options["package-name"] ?? "drizzle-schema",

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -1,4 +1,5 @@
-import type { Model, ModelProperty, Scalar } from "@typespec/compiler";
+import type { Model, ModelProperty, Program, Scalar } from "@typespec/compiler";
+import { getMaxLength } from "@typespec/compiler";
 import { toSnakeCase } from "../generators/naming.js";
 import { StateKeys } from "../lib.js";
 import type {
@@ -113,7 +114,10 @@ export function buildIR(program: ProgramStateAccess): {
       const isPk = pkFieldState.has(modelProp);
       if (isPk) pkColumns.push(propName);
 
-      const refTarget = referencesState.get(modelProp) as ModelProperty | undefined;
+      const refEntry = referencesState.get(modelProp) as
+        | { ref: ModelProperty; onDelete?: "CASCADE" | "RESTRICT" }
+        | undefined;
+      const refTarget = refEntry?.ref;
       const uuidMeta = uuidState.get(modelProp) as UuidMeta | undefined;
       const isCreatedAt = createdAtState.has(modelProp);
       const isUpdatedAt = updatedAtState.has(modelProp);
@@ -123,7 +127,7 @@ export function buildIR(program: ProgramStateAccess): {
       const maxVal = maxValueState.get(modelProp) as number | undefined;
       const vis = visibilityState.get(modelProp) as string | undefined;
 
-      const fieldType = resolveFieldType(modelProp, uuidMeta);
+      const fieldType = resolveFieldType(modelProp, uuidMeta, program);
       const columnName = toSnakeCase(propName);
 
       // Collect enum definitions
@@ -161,6 +165,9 @@ export function buildIR(program: ProgramStateAccess): {
               tableName: refTableMeta.name,
               fieldName: refTarget.name,
             };
+            if (refEntry?.onDelete) {
+              field.references.onDelete = refEntry.onDelete === "CASCADE" ? "cascade" : "restrict";
+            }
           }
         }
       }
@@ -239,14 +246,18 @@ export function buildIR(program: ProgramStateAccess): {
   return { tables, enums };
 }
 
-function resolveFieldType(prop: ModelProperty, uuidMeta: UuidMeta | undefined): FieldType {
+function resolveFieldType(
+  prop: ModelProperty,
+  uuidMeta: UuidMeta | undefined,
+  program: ProgramStateAccess,
+): FieldType {
   if (uuidMeta) {
     return { kind: "uuid", encoding: uuidMeta.encoding as UuidEncoding };
   }
 
   const type = prop.type;
   if (type.kind === "Scalar") {
-    return resolveScalarType(type as Scalar);
+    return resolveScalarType(type as Scalar, program);
   }
 
   // Enum types — TypeSpec Enum kind
@@ -264,13 +275,19 @@ function resolveFieldType(prop: ModelProperty, uuidMeta: UuidMeta | undefined): 
     return { kind: "enum", enumName, values };
   }
 
+  if (type.kind === "Model") {
+    return { kind: "jsonb" };
+  }
+
   return { kind: "text" };
 }
 
-function resolveScalarType(scalar: Scalar): FieldType {
+function resolveScalarType(scalar: Scalar, program: ProgramStateAccess): FieldType {
+  const maxLength = getMaxLength(program as unknown as Program, scalar as unknown as Scalar);
+
   switch (scalar.name) {
     case "string":
-      return { kind: "text" };
+      return maxLength !== undefined ? { kind: "varchar", length: maxLength } : { kind: "text" };
     case "int32":
       return { kind: "integer" };
     case "int64":
@@ -285,8 +302,12 @@ function resolveScalarType(scalar: Scalar): FieldType {
       return { kind: "timestamp" };
   }
 
+  if (maxLength !== undefined) {
+    return { kind: "varchar", length: maxLength };
+  }
+
   if (scalar.baseScalar) {
-    return resolveScalarType(scalar.baseScalar);
+    return resolveScalarType(scalar.baseScalar, program);
   }
 
   return { kind: "text" };

--- a/src/ir/remit-builder.ts
+++ b/src/ir/remit-builder.ts
@@ -51,10 +51,20 @@ interface CollectionMember {
   pkAttr: string;
 }
 
-export function buildRemitIR(program: Program): {
+export interface RemitBuildOptions {
+  enumAsText?: boolean;
+  foreignKeys?: boolean;
+}
+
+export function buildRemitIR(
+  program: Program,
+  options: RemitBuildOptions = {},
+): {
   tables: TableDef[];
   enums: EnumDef[];
 } {
+  const enumAsText = options.enumAsText ?? false;
+  const foreignKeys = options.foreignKeys ?? true;
   const tables: TableDef[] = [];
   const enums: EnumDef[] = [];
   const seenEnums = new Set<string>();
@@ -79,10 +89,11 @@ export function buildRemitIR(program: Program): {
     const patterns = decoratorsByName(model, "@index").map(readIndexDecorator);
     const primary = patterns.find((p) => !p.index);
     const pkColumns = primary ? [...primary.pk, ...primary.sk] : [];
+    const singlePkColumn = pkColumns.length === 1 ? pkColumns[0] : undefined;
 
     const fields: FieldDef[] = [];
     for (const [propName, prop] of model.properties) {
-      const resolved = resolveFieldType(prop);
+      const resolved = resolveFieldType(prop, enumAsText);
       if (resolved.enumDef && !seenEnums.has(resolved.enumDef.name)) {
         seenEnums.add(resolved.enumDef.name);
         enums.push(resolved.enumDef);
@@ -97,6 +108,10 @@ export function buildRemitIR(program: Program): {
         createdAt: false,
         updatedAt: false,
       };
+
+      if (propName === singlePkColumn && resolved.type.kind === "text") {
+        field.autoGenerateId = true;
+      }
 
       const defaultValue = extractDefaultValue(prop);
       if (defaultValue !== undefined) field.defaultValue = defaultValue;
@@ -138,7 +153,7 @@ export function buildRemitIR(program: Program): {
     });
   }
 
-  applyCollectionForeignKeys(tables, collections);
+  if (foreignKeys) applyCollectionForeignKeys(tables, collections);
 
   return { tables, enums };
 }
@@ -251,11 +266,17 @@ interface ResolvedField {
   enumDef?: EnumDef;
 }
 
-function resolveFieldType(prop: ModelProperty): ResolvedField {
+function resolveFieldType(prop: ModelProperty, enumAsText: boolean): ResolvedField {
   const type = prop.type;
 
   if (type.kind === "Scalar") return { type: resolveScalarType(type) };
-  if (type.kind === "Enum") return resolveEnumType(type);
+  if (type.kind === "Enum") {
+    if (!enumAsText) return resolveEnumType(type);
+    const values = [...type.members.values()].map((m) =>
+      m.value !== undefined ? String(m.value) : m.name,
+    );
+    return { type: { kind: "textEnum", values } };
+  }
   if (type.kind === "Model") return { type: { kind: "jsonb" } };
   if (type.kind === "Union") {
     return isStringUnion(type) ? { type: { kind: "text" } } : { type: { kind: "jsonb" } };

--- a/src/ir/remit-builder.ts
+++ b/src/ir/remit-builder.ts
@@ -6,6 +6,8 @@ import type {
   Program,
   Scalar,
   Tuple,
+  Type,
+  Union,
 } from "@typespec/compiler";
 import { navigateProgram } from "@typespec/compiler";
 import { toSnakeCase } from "../generators/naming.js";
@@ -255,9 +257,39 @@ function resolveFieldType(prop: ModelProperty): ResolvedField {
   if (type.kind === "Scalar") return { type: resolveScalarType(type) };
   if (type.kind === "Enum") return resolveEnumType(type);
   if (type.kind === "Model") return { type: { kind: "jsonb" } };
-  if (type.kind === "Union") return { type: { kind: "jsonb" } };
+  if (type.kind === "Union") {
+    return isStringUnion(type) ? { type: { kind: "text" } } : { type: { kind: "jsonb" } };
+  }
 
   return { type: { kind: "text" } };
+}
+
+/**
+ * A union whose every variant is a string (a string scalar, a string-valued enum,
+ * or a string literal) is a constrained string, not a structured value — it maps to
+ * a text column. `MessageFlagValue` (system flag | keyword flag | free string) is the
+ * canonical case. A union with any non-string variant is stored as jsonb.
+ */
+function isStringUnion(union: Union): boolean {
+  const variants = [...union.variants.values()];
+  if (variants.length === 0) return false;
+  return variants.every((variant) => isStringLike(variant.type));
+}
+
+function isStringLike(type: Type): boolean {
+  if (type.kind === "String") return true;
+  if (type.kind === "Scalar") return scalarIsString(type);
+  if (type.kind === "Enum") {
+    return [...type.members.values()].every(
+      (m) => m.value === undefined || typeof m.value === "string",
+    );
+  }
+  return false;
+}
+
+function scalarIsString(scalar: Scalar): boolean {
+  if (scalar.name === "string") return true;
+  return scalar.baseScalar ? scalarIsString(scalar.baseScalar) : false;
 }
 
 function resolveScalarType(scalar: Scalar): FieldType {

--- a/src/ir/remit-builder.ts
+++ b/src/ir/remit-builder.ts
@@ -1,6 +1,5 @@
 import type {
   DecoratorApplication,
-  Enum,
   Model,
   ModelProperty,
   Program,
@@ -52,8 +51,8 @@ interface CollectionMember {
 }
 
 export interface RemitBuildOptions {
-  enumAsText?: boolean;
   foreignKeys?: boolean;
+  idDefault?: boolean;
 }
 
 export function buildRemitIR(
@@ -63,11 +62,10 @@ export function buildRemitIR(
   tables: TableDef[];
   enums: EnumDef[];
 } {
-  const enumAsText = options.enumAsText ?? false;
   const foreignKeys = options.foreignKeys ?? true;
+  const idDefault = options.idDefault ?? false;
   const tables: TableDef[] = [];
   const enums: EnumDef[] = [];
-  const seenEnums = new Set<string>();
 
   const models: Model[] = [];
   navigateProgram(program, {
@@ -88,17 +86,20 @@ export function buildRemitIR(
 
     const patterns = decoratorsByName(model, "@index").map(readIndexDecorator);
     const primary = patterns.find((p) => !p.index);
-    const pkColumns = primary ? [...primary.pk, ...primary.sk] : [];
+    const primaryColumns = primary ? [...primary.pk, ...primary.sk] : [];
+
+    // The primary key is the entity's own identity field (`<entity>Id`) as a
+    // single column when it exists. The ElectroDB primary index is a DynamoDB
+    // access pattern (a pk/sk composite), not the entity's identity — it becomes
+    // an ordinary secondary index. Entities with no `<entity>Id` field (a lock
+    // keyed by mailbox + event) keep the composite primary as their key.
+    const idField = `${entityName}Id`;
+    const pkColumns = model.properties.has(idField) ? [idField] : primaryColumns;
     const singlePkColumn = pkColumns.length === 1 ? pkColumns[0] : undefined;
 
     const fields: FieldDef[] = [];
     for (const [propName, prop] of model.properties) {
-      const resolved = resolveFieldType(prop, enumAsText);
-      if (resolved.enumDef && !seenEnums.has(resolved.enumDef.name)) {
-        seenEnums.add(resolved.enumDef.name);
-        enums.push(resolved.enumDef);
-      }
-
+      const resolved = resolveFieldType(prop);
       const columnName = readLabel(prop) ?? toSnakeCase(propName);
       const field: FieldDef = {
         name: propName,
@@ -109,7 +110,7 @@ export function buildRemitIR(
         updatedAt: false,
       };
 
-      if (propName === singlePkColumn && resolved.type.kind === "text") {
+      if (idDefault && propName === singlePkColumn && resolved.type.kind === "text") {
         field.autoGenerateId = true;
       }
 
@@ -119,13 +120,17 @@ export function buildRemitIR(
       fields.push(field);
     }
 
+    const sameColumns = (cols: string[]): boolean =>
+      cols.length === pkColumns.length && cols.every((c, i) => c === pkColumns[i]);
+
     const indexes: IndexDef[] = patterns
-      .filter((p) => p.index && p.pk.length + p.sk.length > 0)
+      .filter((p) => p.pk.length + p.sk.length > 0)
       .map((p) => ({
-        name: `${sqlTableName}_${toSnakeCase(p.name)}`,
+        name: p.index ? `${sqlTableName}_${toSnakeCase(p.name)}` : `${sqlTableName}_primary`,
         columns: [...p.pk, ...p.sk],
         unique: false,
-      }));
+      }))
+      .filter((idx) => !sameColumns(idx.columns));
 
     for (const pattern of patterns) {
       if (!pattern.collection) continue;
@@ -263,15 +268,16 @@ function tupleNames(tuple: Tuple): string[] {
 
 interface ResolvedField {
   type: FieldType;
-  enumDef?: EnumDef;
 }
 
-function resolveFieldType(prop: ModelProperty, enumAsText: boolean): ResolvedField {
+function resolveFieldType(prop: ModelProperty): ResolvedField {
   const type = prop.type;
 
   if (type.kind === "Scalar") return { type: resolveScalarType(type) };
+  // Remit stores enums as strings (parity with the DynamoDB single-table port),
+  // so an enum becomes a text column narrowed by a `$type` union rather than a
+  // pgEnum — pgEnum would need an `ALTER TYPE` for every new value.
   if (type.kind === "Enum") {
-    if (!enumAsText) return resolveEnumType(type);
     const values = [...type.members.values()].map((m) =>
       m.value !== undefined ? String(m.value) : m.name,
     );
@@ -334,18 +340,6 @@ function resolveScalarType(scalar: Scalar): FieldType {
   if (scalar.baseScalar) return resolveScalarType(scalar.baseScalar);
 
   return { kind: "text" };
-}
-
-function resolveEnumType(enumType: Enum): ResolvedField {
-  const values = [...enumType.members.values()].map((m) =>
-    m.value !== undefined ? String(m.value) : m.name,
-  );
-  const base = lowerFirst(enumType.name);
-  const enumName = `${base}Enum`;
-  return {
-    type: { kind: "enum", enumName, values },
-    enumDef: { name: enumName, sqlName: toSnakeCase(base), values },
-  };
 }
 
 function extractDefaultValue(prop: ModelProperty): unknown {

--- a/src/ir/remit-builder.ts
+++ b/src/ir/remit-builder.ts
@@ -1,0 +1,329 @@
+import type {
+  DecoratorApplication,
+  Enum,
+  Model,
+  ModelProperty,
+  Program,
+  Scalar,
+  Tuple,
+} from "@typespec/compiler";
+import { navigateProgram } from "@typespec/compiler";
+import { toSnakeCase } from "../generators/naming.js";
+import type {
+  EnumDef,
+  FieldDef,
+  FieldType,
+  IndexDef,
+  ReferentialAction,
+  TableDef,
+} from "./types.js";
+
+/**
+ * Remit front-end for the Drizzle emitter.
+ *
+ * Reads the ElectroDB TypeSpec vocabulary emitted by `typespec-electrodb-emitter`
+ * (`@entity`, `@index`, `@createdAt`, `@updatedAt`, `@label`) and produces the same
+ * IR the `@table`-based front-end produces, so the back-end (schema/relations/
+ * describe/types generators) is reused unchanged.
+ *
+ * Decorators are read by name off `Type.decorators` (`DecoratorApplication.definition.name`)
+ * rather than by importing the electrodb emitter's private state-key symbols — the
+ * decorator surface is the stable contract; the state keys are an implementation detail.
+ *
+ * Relations are derived from ElectroDB collections: a `collection` shared by ≥2 entities
+ * on indexes that share the same pk-attribute NAME means that named attribute is the
+ * foreign key. The member whose PRIMARY index pk is exactly that attribute is the owner;
+ * every other member's same-named column references it.
+ */
+
+interface AccessPattern {
+  name: string;
+  index?: string;
+  collection?: string;
+  pk: string[];
+  sk: string[];
+}
+
+interface CollectionMember {
+  table: string;
+  pkAttr: string;
+}
+
+export function buildRemitIR(program: Program): {
+  tables: TableDef[];
+  enums: EnumDef[];
+} {
+  const tables: TableDef[] = [];
+  const enums: EnumDef[] = [];
+  const seenEnums = new Set<string>();
+
+  const models: Model[] = [];
+  navigateProgram(program, {
+    model(model) {
+      if (firstDecorator(model, "@entity")) models.push(model);
+    },
+  });
+
+  const collections = new Map<string, CollectionMember[]>();
+
+  for (const model of models) {
+    const entityDec = firstDecorator(model, "@entity");
+    if (!entityDec) continue;
+
+    const entityName = stringArg(entityDec, 0) ?? lowerFirst(model.name);
+    const service = stringArg(entityDec, 1) ?? "remit";
+    const sqlTableName = toSnakeCase(entityName);
+
+    const patterns = decoratorsByName(model, "@index").map(readIndexDecorator);
+    const primary = patterns.find((p) => !p.index);
+    const pkColumns = primary ? [...primary.pk, ...primary.sk] : [];
+
+    const fields: FieldDef[] = [];
+    for (const [propName, prop] of model.properties) {
+      const resolved = resolveFieldType(prop);
+      if (resolved.enumDef && !seenEnums.has(resolved.enumDef.name)) {
+        seenEnums.add(resolved.enumDef.name);
+        enums.push(resolved.enumDef);
+      }
+
+      const columnName = readLabel(prop) ?? toSnakeCase(propName);
+      const field: FieldDef = {
+        name: propName,
+        columnName,
+        type: resolved.type,
+        nullable: prop.optional,
+        createdAt: false,
+        updatedAt: false,
+      };
+
+      const defaultValue = extractDefaultValue(prop);
+      if (defaultValue !== undefined) field.defaultValue = defaultValue;
+
+      fields.push(field);
+    }
+
+    const indexes: IndexDef[] = patterns
+      .filter((p) => p.index && p.pk.length + p.sk.length > 0)
+      .map((p) => ({
+        name: `${sqlTableName}_${toSnakeCase(p.name)}`,
+        columns: [...p.pk, ...p.sk],
+        unique: false,
+      }));
+
+    for (const pattern of patterns) {
+      if (!pattern.collection) continue;
+      const pkAttr = pattern.pk[0];
+      if (!pkAttr) continue;
+      const members = collections.get(pattern.collection) ?? [];
+      members.push({ table: model.name, pkAttr });
+      collections.set(pattern.collection, members);
+    }
+
+    tables.push({
+      name: model.name,
+      service,
+      tableName: sqlTableName,
+      primaryKey: {
+        tableName: sqlTableName,
+        columns: pkColumns,
+        isComposite: pkColumns.length > 1,
+      },
+      fields,
+      foreignKeys: [],
+      isJunction: false,
+      indexes,
+      uniqueConstraints: [],
+    });
+  }
+
+  applyCollectionForeignKeys(tables, collections);
+
+  return { tables, enums };
+}
+
+/**
+ * Turn ElectroDB collections into foreign-key references on the IR.
+ *
+ * For each collection with ≥2 distinct member entities, the shared pk-attribute name is
+ * the join column. The member whose primary key is exactly that single attribute is the
+ * owner; every other member's same-named column gets a hard reference to it. Remit
+ * collections model parent-owns-children partitions, so the policy is ON DELETE CASCADE.
+ */
+function applyCollectionForeignKeys(
+  tables: TableDef[],
+  collections: Map<string, CollectionMember[]>,
+): void {
+  const byName = new Map(tables.map((t) => [t.name, t]));
+
+  for (const members of collections.values()) {
+    const distinctTables = new Set(members.map((m) => m.table));
+    if (distinctTables.size < 2) continue;
+
+    const sharedAttr = members[0].pkAttr;
+    if (!members.every((m) => m.pkAttr === sharedAttr)) continue;
+
+    const owner = tables.find(
+      (t) => t.primaryKey.columns.length === 1 && t.primaryKey.columns[0] === sharedAttr,
+    );
+    if (!owner) continue;
+
+    const onDelete: ReferentialAction = "cascade";
+    for (const tableName of distinctTables) {
+      if (tableName === owner.name) continue;
+      const table = byName.get(tableName);
+      const field = table?.fields.find((f) => f.name === sharedAttr);
+      if (!field) continue;
+      field.references = { tableName: owner.name, fieldName: sharedAttr, onDelete };
+    }
+  }
+}
+
+function decoratorsByName(type: Model | ModelProperty, name: string): DecoratorApplication[] {
+  return type.decorators.filter((d) => d.definition?.name === name);
+}
+
+function firstDecorator(
+  type: Model | ModelProperty,
+  name: string,
+): DecoratorApplication | undefined {
+  return decoratorsByName(type, name)[0];
+}
+
+function stringArg(dec: DecoratorApplication, index: number): string | undefined {
+  const arg = dec.args[index];
+  if (!arg) return undefined;
+  if (typeof arg.jsValue === "string") return arg.jsValue;
+  // The electrodb decorators declare their string params as TYPE constraints
+  // (`name: string`, not `valueof string`), so the argument arrives as a String
+  // literal type rather than a marshalled JS string.
+  const value = arg.value as { kind?: string; value?: unknown };
+  if (value?.kind === "String" && typeof value.value === "string") return value.value;
+  return undefined;
+}
+
+function readLabel(prop: ModelProperty): string | undefined {
+  const dec = firstDecorator(prop, "@label");
+  return dec ? stringArg(dec, 0) : undefined;
+}
+
+function readIndexDecorator(dec: DecoratorApplication): AccessPattern {
+  const name = stringArg(dec, 0) ?? "";
+  const patternArg = dec.args[1];
+  const pattern = patternArg && isModel(patternArg.value) ? (patternArg.value as Model) : undefined;
+
+  return {
+    name,
+    index: pattern ? readStringProp(pattern, "index") : undefined,
+    collection: pattern ? readStringProp(pattern, "collection") : undefined,
+    pk: pattern ? readKeyComposite(pattern, "pk") : [],
+    sk: pattern ? readKeyComposite(pattern, "sk") : [],
+  };
+}
+
+function readStringProp(pattern: Model, key: string): string | undefined {
+  const prop = pattern.properties.get(key);
+  if (prop && prop.type.kind === "String") return prop.type.value;
+  return undefined;
+}
+
+function readKeyComposite(pattern: Model, key: string): string[] {
+  const prop = pattern.properties.get(key);
+  if (!prop) return [];
+  const type = prop.type;
+  if (type.kind === "Tuple") return tupleNames(type);
+  if (type.kind === "Model") {
+    const composite = type.properties.get("composite");
+    if (composite && composite.type.kind === "Tuple") return tupleNames(composite.type);
+  }
+  return [];
+}
+
+function tupleNames(tuple: Tuple): string[] {
+  return tuple.values
+    .filter((v): v is ModelProperty => v.kind === "ModelProperty")
+    .map((v) => v.name);
+}
+
+interface ResolvedField {
+  type: FieldType;
+  enumDef?: EnumDef;
+}
+
+function resolveFieldType(prop: ModelProperty): ResolvedField {
+  const type = prop.type;
+
+  if (type.kind === "Scalar") return { type: resolveScalarType(type) };
+  if (type.kind === "Enum") return resolveEnumType(type);
+  if (type.kind === "Model") return { type: { kind: "jsonb" } };
+  if (type.kind === "Union") return { type: { kind: "jsonb" } };
+
+  return { type: { kind: "text" } };
+}
+
+function resolveScalarType(scalar: Scalar): FieldType {
+  switch (scalar.name) {
+    case "int32":
+      return { kind: "integer" };
+    case "int64":
+      return { kind: "bigint" };
+    case "float32":
+      return { kind: "real" };
+    case "float64":
+      return { kind: "doublePrecision" };
+    case "boolean":
+      return { kind: "boolean" };
+    case "utcDateTime":
+      return { kind: "timestamp" };
+    case "string":
+      return { kind: "text" };
+  }
+
+  if (scalar.baseScalar) return resolveScalarType(scalar.baseScalar);
+
+  return { kind: "text" };
+}
+
+function resolveEnumType(enumType: Enum): ResolvedField {
+  const values = [...enumType.members.values()].map((m) =>
+    m.value !== undefined ? String(m.value) : m.name,
+  );
+  const base = lowerFirst(enumType.name);
+  const enumName = `${base}Enum`;
+  return {
+    type: { kind: "enum", enumName, values },
+    enumDef: { name: enumName, sqlName: toSnakeCase(base), values },
+  };
+}
+
+function extractDefaultValue(prop: ModelProperty): unknown {
+  const value =
+    (prop as { defaultValue?: unknown }).defaultValue ?? (prop as { default?: unknown }).default;
+  if (value === null || value === undefined) return undefined;
+
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "object" && value !== null) {
+    const typed = value as { valueKind?: string; value?: unknown; kind?: string; name?: string };
+    if ("value" in typed && typed.value !== undefined) {
+      const inner = typed.value;
+      if (typeof inner === "string" || typeof inner === "number" || typeof inner === "boolean") {
+        return inner;
+      }
+    }
+    if (typed.kind === "EnumMember") {
+      return typed.value !== undefined ? typed.value : typed.name;
+    }
+  }
+
+  return undefined;
+}
+
+function isModel(value: unknown): value is Model {
+  return !!value && typeof value === "object" && (value as { kind?: string }).kind === "Model";
+}
+
+function lowerFirst(name: string): string {
+  return name.charAt(0).toLowerCase() + name.slice(1);
+}

--- a/src/ir/types.ts
+++ b/src/ir/types.ts
@@ -11,8 +11,12 @@ export type FieldType =
   | { kind: "doublePrecision" }
   | { kind: "boolean" }
   | { kind: "timestamp" }
+  | { kind: "jsonb" }
   | { kind: "uuid"; encoding: UuidEncoding }
   | { kind: "enum"; enumName: string; values: string[] };
+
+/** ON DELETE / ON UPDATE referential action for a foreign key */
+export type ReferentialAction = "cascade" | "restrict" | "no action" | "set null" | "set default";
 
 /** Column-level field definition extracted from a TypeSpec model property */
 export interface FieldDef {
@@ -27,6 +31,7 @@ export interface FieldDef {
   references?: {
     tableName: string;
     fieldName: string;
+    onDelete?: ReferentialAction;
   };
   createdAt: boolean;
   updatedAt: boolean;

--- a/src/ir/types.ts
+++ b/src/ir/types.ts
@@ -13,7 +13,8 @@ export type FieldType =
   | { kind: "timestamp" }
   | { kind: "jsonb" }
   | { kind: "uuid"; encoding: UuidEncoding }
-  | { kind: "enum"; enumName: string; values: string[] };
+  | { kind: "enum"; enumName: string; values: string[] }
+  | { kind: "textEnum"; values: string[] };
 
 /** ON DELETE / ON UPDATE referential action for a foreign key */
 export type ReferentialAction = "cascade" | "restrict" | "no action" | "set null" | "set default";
@@ -28,6 +29,12 @@ export interface FieldDef {
     encoding: UuidEncoding;
     autoGenerate: boolean;
   };
+  /**
+   * Emit `.$defaultFn(() => generateBase36Id())` so a text primary key gets a
+   * generated base36 id when the caller omits it. Set for single-column primary
+   * keys that are not native uuid columns.
+   */
+  autoGenerateId?: boolean;
   references?: {
     tableName: string;
     fieldName: string;

--- a/test/codegen/ast-helpers.test.ts
+++ b/test/codegen/ast-helpers.test.ts
@@ -17,6 +17,14 @@ describe("quoted", () => {
   it("wraps a string in double quotes", () => {
     assert.equal(quoted("hello"), '"hello"');
   });
+
+  it("escapes a leading backslash (IMAP system attribute)", () => {
+    assert.equal(quoted("\\NonExistent"), '"\\\\NonExistent"');
+  });
+
+  it("escapes embedded double quotes", () => {
+    assert.equal(quoted('a"b'), '"a\\"b"');
+  });
 });
 
 describe("fnCall", () => {

--- a/test/generators/real-world-fidelity.test.ts
+++ b/test/generators/real-world-fidelity.test.ts
@@ -122,6 +122,42 @@ describe("varchar columns", () => {
   });
 });
 
+describe("textEnum columns", () => {
+  const row: TableDef = {
+    name: "Row",
+    service: "s",
+    tableName: "rows",
+    primaryKey: { tableName: "rows", columns: ["rowId"], isComposite: false },
+    isJunction: false,
+    fields: [
+      baseField("rowId", { columnName: "row_id", type: { kind: "uuid", encoding: "base36" } }),
+      baseField("status", { type: { kind: "textEnum", values: ["active", "deleted"] } }),
+      baseField("phase", {
+        type: { kind: "textEnum", values: ["idle", "done"] },
+        nullable: true,
+      }),
+    ],
+    foreignKeys: [],
+    indexes: [],
+    uniqueConstraints: [],
+  };
+
+  it("emits a text column with a $type union for a non-null enum", () => {
+    const output = generateSchema([row], [], pg);
+    assert.ok(output.includes('status: text("status").$type<"active" | "deleted">().notNull(),'));
+  });
+
+  it("keeps the $type union on a nullable enum (no notNull)", () => {
+    const output = generateSchema([row], [], pg);
+    assert.ok(output.includes('phase: text("phase").$type<"idle" | "done">(),'));
+  });
+
+  it("declares no pgEnum for text-backed enums", () => {
+    const output = generateSchema([row], [], pg);
+    assert.ok(!output.includes("pgEnum"));
+  });
+});
+
 describe("onDelete referential action", () => {
   function tableFor(field: FieldDef): TableDef {
     return {

--- a/test/generators/real-world-fidelity.test.ts
+++ b/test/generators/real-world-fidelity.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { mapFieldToColumn } from "../../src/generators/column-mapper.ts";
+import { generateDescribe } from "../../src/generators/describe-generator.ts";
+import { resolveDialect } from "../../src/generators/dialect.ts";
+import { generateSchema } from "../../src/generators/schema-generator.ts";
+import { buildRelationGraph } from "../../src/ir/relation-graph.ts";
+import type { FieldDef, TableDef } from "../../src/ir/types.ts";
+
+const pg = resolveDialect("pg");
+const sqlite = resolveDialect("sqlite");
+
+function baseField(name: string, over: Partial<FieldDef>): FieldDef {
+  return {
+    name,
+    columnName: name.replace(/([A-Z])/g, "_$1").toLowerCase(),
+    type: { kind: "text" },
+    nullable: false,
+    createdAt: false,
+    updatedAt: false,
+    ...over,
+  };
+}
+
+describe("composite primary key describe", () => {
+  const editionLocale: TableDef = {
+    name: "EditionLocale",
+    service: "bookstore",
+    tableName: "edition_locales",
+    primaryKey: {
+      tableName: "edition_locales",
+      columns: ["editionId", "languageCode"],
+      isComposite: true,
+    },
+    isJunction: false,
+    fields: [
+      baseField("editionId", {
+        columnName: "edition_id",
+        type: { kind: "uuid", encoding: "base36" },
+      }),
+      baseField("languageCode", { columnName: "language_code" }),
+      baseField("translatedTitle", { columnName: "translated_title" }),
+    ],
+    foreignKeys: [],
+    indexes: [],
+    uniqueConstraints: [],
+  };
+
+  const output = generateDescribe([editionLocale], buildRelationGraph([editionLocale]));
+
+  it("emits one parameter per primary-key column", () => {
+    assert.ok(output.includes("  editionId: string,"));
+    assert.ok(output.includes("  languageCode: string,"));
+  });
+
+  it("filters on every primary-key column", () => {
+    assert.ok(output.includes("where: { editionId, languageCode }"));
+  });
+});
+
+describe("jsonb columns", () => {
+  const bookExtra: TableDef = {
+    name: "BookExtra",
+    service: "bookstore",
+    tableName: "book_extras",
+    primaryKey: { tableName: "book_extras", columns: ["bookExtraId"], isComposite: false },
+    isJunction: false,
+    fields: [
+      baseField("bookExtraId", {
+        columnName: "book_extra_id",
+        type: { kind: "uuid", encoding: "base36" },
+      }),
+      baseField("metadata", { type: { kind: "jsonb" } }),
+      baseField("tags", { type: { kind: "jsonb" }, nullable: true }),
+    ],
+    foreignKeys: [],
+    indexes: [],
+    uniqueConstraints: [],
+  };
+
+  it("emits jsonb for pg", () => {
+    const output = generateSchema([bookExtra], [], pg);
+    assert.ok(output.includes('metadata: jsonb("metadata").notNull(),'));
+    assert.ok(output.includes('tags: jsonb("tags"),'));
+    assert.ok(output.includes("jsonb,"));
+  });
+
+  it("maps jsonb to json-mode text for sqlite", () => {
+    const output = generateSchema([bookExtra], [], sqlite);
+    assert.ok(output.includes('metadata: text("metadata", { mode: "json" }).notNull(),'));
+    assert.ok(output.includes('tags: text("tags", { mode: "json" }),'));
+  });
+});
+
+describe("varchar columns", () => {
+  const shortName: TableDef = {
+    name: "ShortName",
+    service: "bookstore",
+    tableName: "short_names",
+    primaryKey: { tableName: "short_names", columns: ["shortNameId"], isComposite: false },
+    isJunction: false,
+    fields: [
+      baseField("shortNameId", {
+        columnName: "short_name_id",
+        type: { kind: "uuid", encoding: "base36" },
+      }),
+      baseField("name", { type: { kind: "varchar", length: 64 } }),
+    ],
+    foreignKeys: [],
+    indexes: [],
+    uniqueConstraints: [],
+  };
+
+  it("emits varchar with length for pg", () => {
+    const output = generateSchema([shortName], [], pg);
+    assert.ok(output.includes('name: varchar("name", { length: 64 }).notNull(),'));
+  });
+
+  it("maps varchar to text with length for sqlite", () => {
+    const output = generateSchema([shortName], [], sqlite);
+    assert.ok(output.includes('name: text("name", { length: 64 }).notNull(),'));
+  });
+});
+
+describe("onDelete referential action", () => {
+  function tableFor(field: FieldDef): TableDef {
+    return {
+      name: "Fk",
+      service: "bookstore",
+      tableName: "fks",
+      primaryKey: { tableName: "fks", columns: ["fkId"], isComposite: false },
+      isJunction: false,
+      fields: [field],
+      foreignKeys: [],
+      indexes: [],
+      uniqueConstraints: [],
+    };
+  }
+
+  it("emits the onDelete option when set", () => {
+    const field = baseField("bookId", {
+      columnName: "book_id",
+      type: { kind: "uuid", encoding: "base36" },
+      references: { tableName: "Book", fieldName: "bookId", onDelete: "cascade" },
+    });
+    const col = mapFieldToColumn(field, tableFor(field), pg);
+    assert.ok(col.includes('.references(() => books.bookId, { onDelete: "cascade" })'));
+  });
+
+  it("emits a bare reference when no policy is set", () => {
+    const field = baseField("translatorId", {
+      columnName: "translator_id",
+      type: { kind: "uuid", encoding: "base36" },
+      nullable: true,
+      references: { tableName: "Translator", fieldName: "translatorId" },
+    });
+    const col = mapFieldToColumn(field, tableFor(field), pg);
+    assert.ok(col.includes(".references(() => translators.translatorId)"));
+    assert.ok(!col.includes("onDelete"));
+  });
+});

--- a/test/integration/assembly.test.ts
+++ b/test/integration/assembly.test.ts
@@ -228,3 +228,40 @@ describe("package assembly", () => {
     assert.ok(index.includes('export * from "./describe.js"'));
   });
 });
+
+describe("schema-only assembly", () => {
+  const schemaOnlyFiles = assemblePackage(bookstoreTables, bookstoreEnums, {
+    ...config,
+    schemaOnly: true,
+  });
+
+  it("omits relations.ts and describe.ts", () => {
+    assert.ok(!schemaOnlyFiles.has("relations.ts"));
+    assert.ok(!schemaOnlyFiles.has("describe.ts"));
+    assert.ok(schemaOnlyFiles.has("schema.ts"));
+    assert.ok(schemaOnlyFiles.has("types.ts"));
+  });
+
+  it("emits types.ts without the Drizzle-v2 client type or relations import", () => {
+    const types = schemaOnlyFiles.get("types.ts");
+    assert.ok(types);
+    assert.ok(!types.includes("DrizzleClient"));
+    assert.ok(!types.includes("PgAsyncDatabase"));
+    assert.ok(!types.includes("./relations.js"));
+    assert.ok(types.includes("base36Uuid"));
+  });
+
+  it("barrels only types and schema", () => {
+    const index = schemaOnlyFiles.get("index.ts");
+    assert.ok(index);
+    assert.ok(!index.includes("./relations.js"));
+    assert.ok(!index.includes("./describe.js"));
+    assert.ok(index.includes("./schema.js"));
+  });
+
+  it("declares a Drizzle-v1-compatible peer range", () => {
+    const pkg = schemaOnlyFiles.get("package.json");
+    assert.ok(pkg);
+    assert.ok(pkg.includes('"drizzle-orm": ">=0.30.0"'));
+  });
+});

--- a/test/integration/remit-frontend.test.ts
+++ b/test/integration/remit-frontend.test.ts
@@ -29,6 +29,16 @@ enum Color {
   Red: "red",
 }
 
+enum SystemFlag {
+  Seen: "\\\\Seen",
+  Answered: "\\\\Answered",
+}
+
+union FlagValue {
+  system: SystemFlag,
+  custom: string,
+}
+
 model Meta {
   score: int32;
 }
@@ -41,6 +51,7 @@ model ThreadMessage {
   threadMessageId: string;
   sentDate: int64;
   star: Color;
+  flag: FlagValue;
   meta?: Meta;
   subject?: string;
   @createdAt createdAt: int64;
@@ -103,6 +114,11 @@ describe("remit entity front-end (buildRemitIR)", () => {
   it("resolves a string-valued enum property to an enum column", () => {
     const star = byName.get("ThreadMessage")?.fields.find((f) => f.name === "star");
     assert.equal(star?.type.kind, "enum");
+  });
+
+  it("resolves a string-valued union to a text column", () => {
+    const flag = byName.get("ThreadMessage")?.fields.find((f) => f.name === "flag");
+    assert.equal(flag?.type.kind, "text");
   });
 
   it("resolves a nested model property to jsonb and marks it nullable", () => {

--- a/test/integration/remit-frontend.test.ts
+++ b/test/integration/remit-frontend.test.ts
@@ -79,6 +79,7 @@ model BodyPart {
 describe("remit entity front-end (buildRemitIR)", () => {
   let tables: TableDef[];
   let byName: Map<string, TableDef>;
+  let program: Awaited<ReturnType<typeof createTestHost>>["program"];
 
   before(async () => {
     const host = await createTestHost();
@@ -92,7 +93,8 @@ describe("remit entity front-end (buildRemitIR)", () => {
     host.addTypeSpecFile("electrodb.tsp", `import "./electrodb.js";\n${STUB_DECORATORS}`);
     host.addTypeSpecFile("main.tsp", MODELS);
     await host.compile("main.tsp");
-    ({ tables } = buildRemitIR(host.program));
+    program = host.program;
+    ({ tables } = buildRemitIR(program));
     byName = new Map(tables.map((t) => [t.name, t]));
   });
 
@@ -116,6 +118,15 @@ describe("remit entity front-end (buildRemitIR)", () => {
     assert.equal(star?.type.kind, "enum");
   });
 
+  it("resolves enums to text-backed union columns and emits no enum defs under enum-mode text", () => {
+    const result = buildRemitIR(program, { enumAsText: true });
+    const star = result.tables
+      .find((t) => t.name === "ThreadMessage")
+      ?.fields.find((f) => f.name === "star");
+    assert.equal(star?.type.kind, "textEnum");
+    assert.equal(result.enums.length, 0);
+  });
+
   it("resolves a string-valued union to a text column", () => {
     const flag = byName.get("ThreadMessage")?.fields.find((f) => f.name === "flag");
     assert.equal(flag?.type.kind, "text");
@@ -136,5 +147,11 @@ describe("remit entity front-end (buildRemitIR)", () => {
   it("does not add a foreign key on the collection owner", () => {
     const owner = byName.get("Message");
     assert.ok(owner?.fields.every((f) => !f.references));
+  });
+
+  it("omits all foreign keys when foreignKeys is false", () => {
+    const result = buildRemitIR(program, { foreignKeys: false });
+    const anyRef = result.tables.some((t) => t.fields.some((f) => f.references));
+    assert.equal(anyRef, false);
   });
 });

--- a/test/integration/remit-frontend.test.ts
+++ b/test/integration/remit-frontend.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import { createTestHost } from "@typespec/compiler/testing";
+import { buildRemitIR } from "../../src/ir/remit-builder.ts";
+import type { TableDef } from "../../src/ir/types.ts";
+
+const STUB_DECORATORS = `
+using TypeSpec.Reflection;
+
+model AccessPattern {
+  index?: string;
+  collection?: string;
+  pk?: ModelProperty[];
+  sk?: ModelProperty[];
+}
+
+extern dec entity(target: Model, entity: string, service: string);
+extern dec index(target: Model, name: string, accessPattern: AccessPattern);
+extern dec label(target: ModelProperty, label: string);
+extern dec createdAt(target: ModelProperty, label?: string);
+extern dec updatedAt(target: ModelProperty, label?: string);
+`;
+
+const MODELS = `
+import "./electrodb.tsp";
+
+enum Color {
+  None: "none",
+  Red: "red",
+}
+
+model Meta {
+  score: int32;
+}
+
+@entity("threadMessage", "remit")
+@index("ThreadMessage", { pk: [ThreadMessage.accountConfigId], sk: [ThreadMessage.threadMessageId] })
+@index("byDate", { index: "lsi1", pk: [ThreadMessage.accountConfigId], sk: [ThreadMessage.sentDate] })
+model ThreadMessage {
+  accountConfigId: string;
+  threadMessageId: string;
+  sentDate: int64;
+  star: Color;
+  meta?: Meta;
+  subject?: string;
+  @createdAt createdAt: int64;
+  @updatedAt updatedAt: int64;
+}
+
+@entity("message", "remit")
+@index("Message", { pk: [Message.messageId] })
+@index("byMsg", { index: "gsi1", collection: "messageData", pk: [Message.messageId] })
+model Message {
+  messageId: string;
+  subject?: string;
+}
+
+@entity("bodyPart", "remit")
+@index("BodyPart", { pk: [BodyPart.bodyPartId] })
+@index("byMsgPart", { index: "gsi1", collection: "messageData", pk: [BodyPart.messageId] })
+model BodyPart {
+  bodyPartId: string;
+  messageId: string;
+  content: string;
+}
+`;
+
+describe("remit entity front-end (buildRemitIR)", () => {
+  let tables: TableDef[];
+  let byName: Map<string, TableDef>;
+
+  before(async () => {
+    const host = await createTestHost();
+    host.addJsFile("electrodb.js", {
+      $entity: () => {},
+      $index: () => {},
+      $label: () => {},
+      $createdAt: () => {},
+      $updatedAt: () => {},
+    });
+    host.addTypeSpecFile("electrodb.tsp", `import "./electrodb.js";\n${STUB_DECORATORS}`);
+    host.addTypeSpecFile("main.tsp", MODELS);
+    await host.compile("main.tsp");
+    ({ tables } = buildRemitIR(host.program));
+    byName = new Map(tables.map((t) => [t.name, t]));
+  });
+
+  it("snake-cases the entity name into the SQL table name", () => {
+    assert.equal(byName.get("ThreadMessage")?.tableName, "thread_message");
+  });
+
+  it("builds a composite primary key from the primary index pk+sk", () => {
+    const pk = byName.get("ThreadMessage")?.primaryKey;
+    assert.deepEqual(pk?.columns, ["accountConfigId", "threadMessageId"]);
+    assert.equal(pk?.isComposite, true);
+  });
+
+  it("names secondary indexes <table>_<accessPattern>", () => {
+    const names = byName.get("ThreadMessage")?.indexes.map((i) => i.name);
+    assert.ok(names?.includes("thread_message_by_date"));
+  });
+
+  it("resolves a string-valued enum property to an enum column", () => {
+    const star = byName.get("ThreadMessage")?.fields.find((f) => f.name === "star");
+    assert.equal(star?.type.kind, "enum");
+  });
+
+  it("resolves a nested model property to jsonb and marks it nullable", () => {
+    const meta = byName.get("ThreadMessage")?.fields.find((f) => f.name === "meta");
+    assert.equal(meta?.type.kind, "jsonb");
+    assert.equal(meta?.nullable, true);
+  });
+
+  it("derives a cascade foreign key from a shared collection", () => {
+    const messageId = byName.get("BodyPart")?.fields.find((f) => f.name === "messageId");
+    assert.equal(messageId?.references?.tableName, "Message");
+    assert.equal(messageId?.references?.onDelete, "cascade");
+  });
+
+  it("does not add a foreign key on the collection owner", () => {
+    const owner = byName.get("Message");
+    assert.ok(owner?.fields.every((f) => !f.references));
+  });
+});

--- a/test/integration/remit-frontend.test.ts
+++ b/test/integration/remit-frontend.test.ts
@@ -74,6 +74,14 @@ model BodyPart {
   messageId: string;
   content: string;
 }
+
+@entity("mailboxLock", "remit")
+@index("MailboxLock", { pk: [MailboxLock.mailboxId], sk: [MailboxLock.eventName] })
+model MailboxLock {
+  mailboxId: string;
+  eventName: string;
+  lockId: string;
+}
 `;
 
 describe("remit entity front-end (buildRemitIR)", () => {
@@ -102,9 +110,20 @@ describe("remit entity front-end (buildRemitIR)", () => {
     assert.equal(byName.get("ThreadMessage")?.tableName, "thread_message");
   });
 
-  it("builds a composite primary key from the primary index pk+sk", () => {
+  it("uses the single-column identity field as the primary key", () => {
     const pk = byName.get("ThreadMessage")?.primaryKey;
-    assert.deepEqual(pk?.columns, ["accountConfigId", "threadMessageId"]);
+    assert.deepEqual(pk?.columns, ["threadMessageId"]);
+    assert.equal(pk?.isComposite, false);
+  });
+
+  it("demotes the electrodb primary composite to a secondary index", () => {
+    const names = byName.get("ThreadMessage")?.indexes.map((i) => i.name);
+    assert.ok(names?.includes("thread_message_primary"));
+  });
+
+  it("keeps a composite primary key for an entity with no identity field", () => {
+    const pk = byName.get("MailboxLock")?.primaryKey;
+    assert.deepEqual(pk?.columns, ["mailboxId", "eventName"]);
     assert.equal(pk?.isComposite, true);
   });
 
@@ -113,18 +132,21 @@ describe("remit entity front-end (buildRemitIR)", () => {
     assert.ok(names?.includes("thread_message_by_date"));
   });
 
-  it("resolves a string-valued enum property to an enum column", () => {
+  it("resolves enums to text-backed union columns and emits no pgEnum defs", () => {
     const star = byName.get("ThreadMessage")?.fields.find((f) => f.name === "star");
-    assert.equal(star?.type.kind, "enum");
+    assert.equal(star?.type.kind, "textEnum");
+    assert.equal(
+      tables.every((t) => t.fields.every((f) => f.type.kind !== "enum")),
+      true,
+    );
   });
 
-  it("resolves enums to text-backed union columns and emits no enum defs under enum-mode text", () => {
-    const result = buildRemitIR(program, { enumAsText: true });
-    const star = result.tables
+  it("attaches a generated id default to single-column text PKs when idDefault is set", () => {
+    const result = buildRemitIR(program, { idDefault: true });
+    const pkField = result.tables
       .find((t) => t.name === "ThreadMessage")
-      ?.fields.find((f) => f.name === "star");
-    assert.equal(star?.type.kind, "textEnum");
-    assert.equal(result.enums.length, 0);
+      ?.fields.find((f) => f.name === "threadMessageId");
+    assert.equal(pkField?.autoGenerateId, true);
   });
 
   it("resolves a string-valued union to a text column", () => {

--- a/test/typespec/decorators.test.ts
+++ b/test/typespec/decorators.test.ts
@@ -123,7 +123,21 @@ describe("decorator functions", () => {
     $references(ctx, sourceProp, targetProp);
 
     const stored = program.stateMap(StateKeys.references).get(sourceProp);
-    assert.equal(stored, targetProp);
+    assert.equal(stored.ref, targetProp);
+    assert.equal(stored.onDelete, undefined);
+  });
+
+  it("$references records onDelete policy when supplied", () => {
+    const program = createMockProgram();
+    const ctx = createMockContext(program);
+    const sourceProp = mockProp("authorId");
+    const targetProp = mockPropWithModel("authorId", {});
+
+    $references(ctx, sourceProp, targetProp, "CASCADE");
+
+    const stored = program.stateMap(StateKeys.references).get(sourceProp);
+    assert.equal(stored.ref, targetProp);
+    assert.equal(stored.onDelete, "CASCADE");
   });
 
   // ===========================================

--- a/test/typespec/emitter.test.ts
+++ b/test/typespec/emitter.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { DecoratorContext, Model, ModelProperty } from "@typespec/compiler";
+import { Numeric } from "@typespec/compiler";
 import { assemblePackage } from "../../src/assembler.ts";
 import {
   $compositeUnique,
@@ -735,5 +736,124 @@ describe("end-to-end: decorators → IR builder → assemblePackage", () => {
     const schemaTs = files.get("schema.ts");
     assert.ok(schemaTs);
     assert.ok(schemaTs.includes('import { sql } from "drizzle-orm"'), "Missing sql import");
+  });
+});
+
+describe("resolution: real-world field types (buildIR)", () => {
+  function buildSingleTable(configure: (ctx: DecoratorContext, model: MockModel) => void) {
+    const program = createMockProgram();
+    const ctx = mockContext(program);
+    const model: MockModel = { kind: "Model", name: "Row", properties: new Map() };
+    const rowId: MockProp = {
+      kind: "ModelProperty",
+      name: "rowId",
+      type: mockScalar("string"),
+      optional: false,
+      model,
+    };
+    model.properties.set("rowId", rowId);
+    $table(ctx, model as unknown as Model, "Row", "test");
+    $primaryKey(ctx, model as unknown as Model, "rows");
+    $pk(ctx, rowId as unknown as ModelProperty);
+    configure(ctx, model);
+    const { tables } = buildIR(program);
+    const table = tables.find((t) => t.name === "Row");
+    assert.ok(table);
+    return table;
+  }
+
+  it("resolves a nested-model property to jsonb", () => {
+    const table = buildSingleTable((_ctx, model) => {
+      model.properties.set("metadata", {
+        kind: "ModelProperty",
+        name: "metadata",
+        type: { kind: "Model", name: "Metadata" } as unknown as ReturnType<typeof mockScalar>,
+        optional: false,
+        model,
+      });
+    });
+    const field = table.fields.find((f) => f.name === "metadata");
+    assert.equal(field?.type.kind, "jsonb");
+  });
+
+  it("resolves a maxLength-bounded scalar to varchar", () => {
+    const program = createMockProgram();
+    const ctx = mockContext(program);
+    const model: MockModel = { kind: "Model", name: "Row", properties: new Map() };
+    const rowId: MockProp = {
+      kind: "ModelProperty",
+      name: "rowId",
+      type: mockScalar("string"),
+      optional: false,
+      model,
+    };
+    const shortString = { kind: "Scalar", name: "ShortString", baseScalar: mockScalar("string") };
+    program.stateMap(Symbol.for("TypeSpec.maxLengthValues")).set(shortString, Numeric("64"));
+    const name: MockProp = {
+      kind: "ModelProperty",
+      name: "name",
+      type: shortString as unknown as ReturnType<typeof mockScalar>,
+      optional: false,
+      model,
+    };
+    model.properties.set("rowId", rowId);
+    model.properties.set("name", name);
+    $table(ctx, model as unknown as Model, "Row", "test");
+    $primaryKey(ctx, model as unknown as Model, "rows");
+    $pk(ctx, rowId as unknown as ModelProperty);
+
+    const { tables } = buildIR(program);
+    const field = tables.find((t) => t.name === "Row")?.fields.find((f) => f.name === "name");
+    assert.deepEqual(field?.type, { kind: "varchar", length: 64 });
+  });
+
+  it("carries the @references onDelete policy into the IR", () => {
+    const program = createMockProgram();
+    const ctx = mockContext(program);
+
+    const target: MockModel = { kind: "Model", name: "Target", properties: new Map() };
+    const targetId: MockProp = {
+      kind: "ModelProperty",
+      name: "targetId",
+      type: mockScalar("string"),
+      optional: false,
+      model: target,
+    };
+    target.properties.set("targetId", targetId);
+    $table(ctx, target as unknown as Model, "Target", "test");
+    $primaryKey(ctx, target as unknown as Model, "targets");
+    $pk(ctx, targetId as unknown as ModelProperty);
+
+    const source: MockModel = { kind: "Model", name: "Source", properties: new Map() };
+    const sourceId: MockProp = {
+      kind: "ModelProperty",
+      name: "sourceId",
+      type: mockScalar("string"),
+      optional: false,
+      model: source,
+    };
+    const fk: MockProp = {
+      kind: "ModelProperty",
+      name: "targetId",
+      type: mockScalar("string"),
+      optional: false,
+      model: source,
+    };
+    source.properties.set("sourceId", sourceId);
+    source.properties.set("targetId", fk);
+    $table(ctx, source as unknown as Model, "Source", "test");
+    $primaryKey(ctx, source as unknown as Model, "sources");
+    $pk(ctx, sourceId as unknown as ModelProperty);
+    $references(
+      ctx,
+      fk as unknown as ModelProperty,
+      targetId as unknown as ModelProperty,
+      "CASCADE",
+    );
+
+    const { tables } = buildIR(program);
+    const sourceTable = tables.find((t) => t.name === "Source");
+    const fkField = sourceTable?.fields.find((f) => f.name === "targetId");
+    assert.equal(fkField?.references?.onDelete, "cascade");
   });
 });

--- a/tsp/main.tsp
+++ b/tsp/main.tsp
@@ -5,7 +5,11 @@ using TypeSpec.Reflection;
 extern dec table(target: Model, name: valueof string, service: valueof string);
 extern dec primaryKey(target: Model, tableName: valueof string);
 extern dec pk(target: ModelProperty);
-extern dec references(target: ModelProperty, ref: ModelProperty);
+extern dec references(
+  target: ModelProperty,
+  ref: ModelProperty,
+  onDelete?: valueof "CASCADE" | "RESTRICT"
+);
 extern dec junction(target: Model);
 extern dec uuid(target: ModelProperty, encoding: valueof string, autoGenerate?: valueof boolean);
 extern dec createdAt(target: ModelProperty);


### PR DESCRIPTION
## What

Adds a second front-end so the emitter can generate a Drizzle package from the ElectroDB `@entity`/`@index` vocabulary, and closes the four Postgres/Drizzle fidelity gaps in #37.

### Remit front-end (`frontend: "remit"`)

New emitter option that reads the decorators emitted by `typespec-electrodb-emitter` instead of this library's own `@table`/`@pk`. Mapping:

- Primary `@index` becomes the primary key — composite when it carries both `pk` and `sk`.
- Each secondary `@index` becomes an index named `<table>_<accessPattern>`.
- A `collection` shared by two or more entities becomes an `ON DELETE CASCADE` foreign key from each member to the entity that owns the shared partition key.

### #37 fidelity gaps (default front-end)

- Nested models and arrays resolve to `jsonb` (pg) / json-mode `text` (sqlite).
- `@maxLength`-bounded scalars resolve to `varchar(n)` / length-bounded `text`.
- Composite-primary-key `describe*` functions take one parameter per key column and filter on all of them.
- `@references` accepts an optional `"CASCADE" | "RESTRICT"` policy, emitted as the Drizzle `onDelete` option.

### Bug fix

String-literal escaping went through raw interpolation, so an enum value with a leading backslash (IMAP system attributes like `\NonExistent`) or an embedded quote emitted invalid TypeScript. Now escaped via `JSON.stringify`.

## Tests

New coverage for every path above (resolution + emission, pg + sqlite where applicable), including a compile-based integration test that drives the remit front-end through the real compiler with stub electrodb decorators. Full suite: 350 passing, lint and type-check clean.

Closes #37. Enables remit-mail/remit#1128 (consumes the published version).

## Compatibility

The #37 fidelity fixes change the emitted schema for existing `drizzle` (default) front-end consumers — correct output that differs from before:
- nested models and arrays now emit `jsonb` instead of `text`
- `@maxLength`-bounded scalars now emit `varchar(n)` instead of `text`
- composite-primary-key `describe*` functions now take one parameter per key column

Regenerate and review the schema diff before upgrading. The `remit` front-end and all new options are additive.
