### PR TITLE
fix: add repository metadata required for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,14 @@
     "dist",
     "tsp"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kattebak/typespec-drizzle-orm-generator.git"
+  },
+  "bugs": {
+    "url": "https://github.com/kattebak/typespec-drizzle-orm-generator/issues"
+  },
+  "homepage": "https://github.com/kattebak/typespec-drizzle-orm-generator#readme",
   "dependencies": {
     "@babel/generator": "^7.29.1",
     "@babel/parser": "^7.29.0",


### PR DESCRIPTION
Add repository, bugs, and homepage fields to package.json so npm provenance can verify the sigstore bundle during trusted-publish releases.