### PR TITLE
test: enforce 83% native line-coverage gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint": "biome check .",
     "fix": "biome check --write .",
     "format": "biome format --write .",
-    "test": "node --test --import=tsx 'src/**/*.test.ts'",
+    "test": "node --test --experimental-test-coverage --test-coverage-lines=83 --test-coverage-exclude='**/*.test.ts' --test-coverage-exclude='src/fixtures/**' --test-coverage-exclude='dist/**' --import=tsx 'src/**/*.test.ts'",
     "pretest": "npm run check",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
Enforce an 83% line-coverage floor via Node native coverage; test files, fixtures, and dist excluded.