### PR TITLE
fix: loosen and mark optional the drizzle-orm peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,12 @@
   },
   "peerDependencies": {
     "@typespec/compiler": ">=1.0.0",
-    "drizzle-orm": ">=1.0.0-beta.1"
+    "drizzle-orm": ">=0.30.0"
+  },
+  "peerDependenciesMeta": {
+    "drizzle-orm": {
+      "optional": true
+    }
   },
   "scripts": {
     "build": "tsgo --project tsconfig.build.json",


### PR DESCRIPTION
The generator is a build-time TypeSpec emitter and never imports `drizzle-orm` (its only runtime deps are babel). It already emits the correct per-mode peer into each *generated* package (`>=0.30.0` under `schema-only`).

The tool-level peer of `>=1.0.0-beta.1` forced every consumer onto drizzle-orm 1.0. Projects on 0.4x (e.g. remit, drizzle-orm 0.45.2) fail `npm ci` with a hard ERESOLVE peer conflict.

This loosens the peer to `>=0.30.0` (the minimum any emit mode supports) and marks it optional, since drizzle-orm is not required to run the emitter. Unblocks remit-mail/remit#1196.

Verified: check + lint clean, 363 tests pass.