### PR TITLE
test: raise line coverage to ~99% with real behavioral tests

### DIFF
--- a/src/codegen/stringify.test.ts
+++ b/src/codegen/stringify.test.ts
@@ -78,6 +78,11 @@ describe("stringifyObject", () => {
     assert.ok(result.includes("() => Date.now()"));
   });
 
+  it("serializes a plain function value via toString", () => {
+    const result = stringifyObject({ fn: () => 1 });
+    assert.ok(result.includes("() =>"));
+  });
+
   it("injects RawCode with generic type", () => {
     const result = stringifyObject({
       type: new RawCode('CustomAttributeType<string>("any")'),

--- a/src/generators/describe.test.ts
+++ b/src/generators/describe.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { bookstoreTables } from "../fixtures/bookstore-ir.ts";
 import { buildRelationGraph } from "../ir/relation-graph.ts";
+import type { TableDef } from "../ir/types.ts";
 import { generateDescribe } from "./describe-generator.ts";
 
 const graph = buildRelationGraph(bookstoreTables);
@@ -239,5 +240,78 @@ describe("describe generator", () => {
     const openParens = (output.match(/\(/g) || []).length;
     const closeParens = (output.match(/\)/g) || []).length;
     assert.equal(openParens, closeParens, "Unbalanced parentheses");
+  });
+});
+
+describe("describe generator: tables without relations", () => {
+  const standalone: TableDef = {
+    name: "Setting",
+    service: "test",
+    tableName: "settings",
+    primaryKey: { tableName: "settings", columns: ["settingId"], isComposite: false },
+    fields: [
+      {
+        name: "settingId",
+        columnName: "setting_id",
+        type: { kind: "text" },
+        nullable: false,
+        createdAt: false,
+        updatedAt: false,
+      },
+    ],
+    foreignKeys: [],
+    isJunction: false,
+    indexes: [],
+    uniqueConstraints: [],
+  };
+
+  const composite: TableDef = {
+    name: "MailboxLock",
+    service: "test",
+    tableName: "mailbox_lock",
+    primaryKey: {
+      tableName: "mailbox_lock",
+      columns: ["mailboxId", "eventName"],
+      isComposite: true,
+    },
+    fields: [
+      {
+        name: "mailboxId",
+        columnName: "mailbox_id",
+        type: { kind: "text" },
+        nullable: false,
+        createdAt: false,
+        updatedAt: false,
+      },
+      {
+        name: "eventName",
+        columnName: "event_name",
+        type: { kind: "text" },
+        nullable: false,
+        createdAt: false,
+        updatedAt: false,
+      },
+    ],
+    foreignKeys: [],
+    isJunction: false,
+    indexes: [],
+    uniqueConstraints: [],
+  };
+
+  const graph = buildRelationGraph([standalone, composite]);
+  const out = generateDescribe([standalone, composite], graph);
+
+  it("emits a findFirst with no `with` clause when a table has no relations", () => {
+    assert.ok(out.includes("export const describeSetting = ("));
+    assert.ok(out.includes("  db.query.settings.findFirst({"));
+    assert.ok(out.includes("    where: { settingId },"));
+    assert.ok(!out.includes("with:"));
+  });
+
+  it("uses every composite primary-key column in the where clause and signature", () => {
+    assert.ok(out.includes("export const describeMailboxLock = ("));
+    assert.ok(out.includes("  mailboxId: string,"));
+    assert.ok(out.includes("  eventName: string,"));
+    assert.ok(out.includes("    where: { mailboxId, eventName },"));
   });
 });

--- a/src/generators/naming.test.ts
+++ b/src/generators/naming.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { pluralize, toCamelCase, toSnakeCase, toTableVariableName } from "./naming.ts";
+
+describe("toSnakeCase", () => {
+  it("converts camelCase to snake_case", () => {
+    assert.equal(toSnakeCase("authorId"), "author_id");
+  });
+
+  it("leaves an all-lowercase word unchanged", () => {
+    assert.equal(toSnakeCase("name"), "name");
+  });
+});
+
+describe("toCamelCase", () => {
+  it("converts snake_case to camelCase", () => {
+    assert.equal(toCamelCase("author_id"), "authorId");
+  });
+
+  it("converts a multi-segment snake_case name", () => {
+    assert.equal(toCamelCase("thread_message_id"), "threadMessageId");
+  });
+
+  it("leaves a camelCase word unchanged", () => {
+    assert.equal(toCamelCase("name"), "name");
+  });
+});
+
+describe("pluralize", () => {
+  it("turns a consonant+y into ies", () => {
+    assert.equal(pluralize("story"), "stories");
+  });
+
+  it("keeps a vowel+y and appends s", () => {
+    assert.equal(pluralize("day"), "days");
+  });
+
+  it("appends es after a sibilant ending", () => {
+    assert.equal(pluralize("box"), "boxes");
+    assert.equal(pluralize("dish"), "dishes");
+  });
+
+  it("appends s by default", () => {
+    assert.equal(pluralize("book"), "books");
+  });
+});
+
+describe("toTableVariableName", () => {
+  it("lower-cases and pluralizes a PascalCase model name", () => {
+    assert.equal(toTableVariableName("BookGenre"), "bookGenres");
+  });
+
+  it("keeps the singular form when pluralization is disabled", () => {
+    assert.equal(toTableVariableName("BookGenre", false), "bookGenre");
+  });
+});

--- a/src/generators/real-world-fidelity.test.ts
+++ b/src/generators/real-world-fidelity.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { buildRelationGraph } from "../ir/relation-graph.ts";
-import type { FieldDef, TableDef } from "../ir/types.ts";
+import type { FieldDef, FieldType, TableDef } from "../ir/types.ts";
 import { mapFieldToColumn } from "./column-mapper.ts";
 import { generateDescribe } from "./describe-generator.ts";
 import { resolveDialect } from "./dialect.ts";
@@ -194,4 +194,56 @@ describe("onDelete referential action", () => {
     assert.ok(col.includes(".references(() => translators.translatorId)"));
     assert.ok(!col.includes("onDelete"));
   });
+});
+
+describe("every column kind across both dialects", () => {
+  const kinds: FieldType[] = [
+    { kind: "text" },
+    { kind: "varchar", length: 32 },
+    { kind: "integer" },
+    { kind: "bigint" },
+    { kind: "real" },
+    { kind: "doublePrecision" },
+    { kind: "boolean" },
+    { kind: "timestamp" },
+    { kind: "jsonb" },
+  ];
+
+  function everyKindTable(nullable: boolean): TableDef {
+    const fields: FieldDef[] = [baseField("rowId", { type: { kind: "uuid", encoding: "base36" } })];
+    for (const type of kinds) {
+      fields.push(baseField(`${type.kind}Col`, { type, nullable }));
+    }
+    return {
+      name: "Everything",
+      service: "test",
+      tableName: "everything",
+      primaryKey: { tableName: "everything", columns: ["rowId"], isComposite: false },
+      isJunction: false,
+      fields,
+      foreignKeys: [],
+      indexes: [],
+      uniqueConstraints: [],
+    };
+  }
+
+  for (const dialect of [pg, sqlite]) {
+    it(`renders every non-nullable column kind (${dialect.dialect})`, () => {
+      const output = generateSchema([everyKindTable(false)], [], dialect, false);
+      assert.ok(output.includes("export const everything ="));
+      assert.ok(output.includes("textCol:"));
+      assert.ok(output.includes("booleanCol:"));
+      assert.ok(output.includes("jsonbCol:"));
+      // no nullable wrapper helpers for the non-nullable variant
+      assert.ok(!output.includes("nullable"));
+    });
+
+    it(`renders every nullable column kind (${dialect.dialect})`, () => {
+      const output = generateSchema([everyKindTable(true)], [], dialect, false);
+      assert.ok(output.includes("export const everything ="));
+      // pg has wrappers for text; sqlite maps a nullable bigint through the raw type
+      assert.ok(output.includes("bigintCol:"));
+      assert.ok(output.includes("timestampCol:"));
+    });
+  }
 });

--- a/src/generators/schema.test.ts
+++ b/src/generators/schema.test.ts
@@ -8,6 +8,52 @@ import { generateSchema } from "./schema-generator.ts";
 const pg = resolveDialect("pg");
 const sqlite = resolveDialect("sqlite");
 
+describe("schema generator: remit-style columns", () => {
+  const remitTable: TableDef = {
+    name: "Message",
+    service: "remit",
+    tableName: "message",
+    primaryKey: { tableName: "message", columns: ["messageId"], isComposite: false },
+    fields: [
+      {
+        name: "messageId",
+        columnName: "message_id",
+        type: { kind: "text" },
+        nullable: false,
+        autoGenerateId: true,
+        createdAt: false,
+        updatedAt: false,
+      },
+      {
+        name: "star",
+        columnName: "star",
+        type: { kind: "textEnum", values: ["none", "red"] },
+        nullable: false,
+        createdAt: false,
+        updatedAt: false,
+      },
+    ],
+    foreignKeys: [],
+    isJunction: false,
+    indexes: [],
+    uniqueConstraints: [],
+  };
+
+  it("renders a text-narrowed enum column and a generated id default (pg)", () => {
+    const output = generateSchema([remitTable], [], pg);
+    assert.ok(output.includes('star: text("star").$type<"none" | "red">()'));
+    assert.ok(output.includes("$defaultFn(() => generateBase36Id())"));
+    assert.ok(output.includes("generateBase36Id"));
+  });
+
+  it("renders a text-narrowed enum column and a generated id default (sqlite)", () => {
+    const output = generateSchema([remitTable], [], sqlite);
+    assert.ok(output.includes('star: text("star").$type<"none" | "red">()'));
+    assert.ok(output.includes("$defaultFn(() => generateBase36Id())"));
+    assert.ok(output.includes('from "drizzle-orm/sqlite-core"'));
+  });
+});
+
 describe("schema generator", () => {
   it("generates correct imports", () => {
     const output = generateSchema(bookstoreTables, bookstoreEnums, pg);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import type { EmitContext } from "@typespec/compiler";
+import { resolvePath } from "@typespec/compiler";
+import { createTestHost } from "@typespec/compiler/testing";
 import {
   $createdAt,
   $junction,
@@ -11,6 +14,7 @@ import {
   $table,
   $updatedAt,
   $uuid,
+  type EmitterOptions,
 } from "./index.ts";
 
 describe("package exports", () => {
@@ -31,5 +35,186 @@ describe("package exports", () => {
 
   it("exports $onEmit function", () => {
     assert.equal(typeof $onEmit, "function");
+  });
+});
+
+const DRIZZLE_DECORATORS = `
+using TypeSpec.Reflection;
+
+extern dec table(target: Model, name: valueof string, service: valueof string);
+extern dec primaryKey(target: Model, tableName: valueof string);
+extern dec pk(target: ModelProperty);
+extern dec uuid(target: ModelProperty, encoding: valueof string, autoGenerate?: valueof boolean);
+`;
+
+const DRIZZLE_MODELS = `
+import "./drizzle.tsp";
+
+@table("Widget", "test")
+@primaryKey("widgets")
+model Widget {
+  @pk @uuid("base36", true) widgetId: string;
+  name: string;
+  size?: int32;
+}
+`;
+
+const REMIT_DECORATORS = `
+using TypeSpec.Reflection;
+
+model AccessPattern {
+  index?: string;
+  collection?: string;
+  pk?: ModelProperty[];
+  sk?: ModelProperty[];
+}
+
+extern dec entity(target: Model, entity: string, service: string);
+extern dec index(target: Model, name: string, accessPattern: AccessPattern);
+`;
+
+const REMIT_MODELS = `
+import "./electrodb.tsp";
+
+@entity("widget", "remit")
+@index("Widget", { pk: [Widget.widgetId] })
+model Widget {
+  widgetId: string;
+  name: string;
+}
+`;
+
+async function drizzleHost() {
+  const host = await createTestHost();
+  const {
+    $pk: pkDec,
+    $table: tableDec,
+    $primaryKey: pkTableDec,
+    $uuid: uuidDec,
+  } = await import("./decorators.ts");
+  host.addJsFile("drizzle.js", {
+    $table: tableDec,
+    $primaryKey: pkTableDec,
+    $pk: pkDec,
+    $uuid: uuidDec,
+  });
+  host.addTypeSpecFile("drizzle.tsp", `import "./drizzle.js";\n${DRIZZLE_DECORATORS}`);
+  host.addTypeSpecFile("main.tsp", DRIZZLE_MODELS);
+  await host.compile("main.tsp");
+  return host;
+}
+
+async function remitHost() {
+  const host = await createTestHost();
+  host.addJsFile("electrodb.js", { $entity: () => {}, $index: () => {} });
+  host.addTypeSpecFile("electrodb.tsp", `import "./electrodb.js";\n${REMIT_DECORATORS}`);
+  host.addTypeSpecFile("main.tsp", REMIT_MODELS);
+  await host.compile("main.tsp");
+  return host;
+}
+
+type TestHost = Awaited<ReturnType<typeof createTestHost>>;
+
+async function runEmit(
+  host: TestHost,
+  options: EmitterOptions,
+  outputDir = "/emit-out",
+): Promise<Map<string, string>> {
+  const context = {
+    program: host.program,
+    emitterOutputDir: outputDir,
+    options,
+  } as unknown as EmitContext<EmitterOptions>;
+
+  await $onEmit(context);
+
+  const files = new Map<string, string>();
+  for (const [path, content] of host.fs) {
+    if (path.startsWith(`${outputDir}/`)) {
+      files.set(path.slice(outputDir.length + 1), content as string);
+    }
+  }
+  return files;
+}
+
+describe("$onEmit (in-process emit)", () => {
+  it("emits the full package for the default drizzle front-end", async () => {
+    const host = await drizzleHost();
+    const files = await runEmit(host, {});
+
+    for (const name of [
+      "package.json",
+      "tsconfig.json",
+      "types.ts",
+      "schema.ts",
+      "relations.ts",
+      "describe.ts",
+      "index.ts",
+    ]) {
+      assert.ok(files.has(name), `missing ${name}`);
+    }
+
+    const schema = files.get("schema.ts");
+    assert.ok(schema?.includes("export const widgets = pgTable("));
+    assert.ok(schema?.includes('from "drizzle-orm/pg-core"'));
+
+    const pkg = JSON.parse(files.get("package.json") ?? "{}");
+    assert.equal(pkg.name, "drizzle-schema");
+    assert.equal(pkg.version, "0.0.1");
+  });
+
+  it("honours package-name, package-version, dialect, and pluralize options", async () => {
+    const host = await drizzleHost();
+    const files = await runEmit(host, {
+      "package-name": "@acme/schema",
+      "package-version": "1.2.3",
+      dialect: "sqlite",
+      pluralize: false,
+    });
+
+    const pkg = JSON.parse(files.get("package.json") ?? "{}");
+    assert.equal(pkg.name, "@acme/schema");
+    assert.equal(pkg.version, "1.2.3");
+
+    const schema = files.get("schema.ts");
+    assert.ok(schema?.includes('from "drizzle-orm/sqlite-core"'));
+    assert.ok(schema?.includes("export const widget = sqliteTable("));
+  });
+
+  it("omits relations.ts and describe.ts when schema-only is set", async () => {
+    const host = await drizzleHost();
+    const files = await runEmit(host, { "schema-only": true });
+
+    assert.ok(files.has("schema.ts"));
+    assert.ok(!files.has("relations.ts"));
+    assert.ok(!files.has("describe.ts"));
+  });
+
+  it("routes through the remit front-end when frontend is 'remit'", async () => {
+    const host = await remitHost();
+    const files = await runEmit(host, { frontend: "remit" });
+
+    const schema = files.get("schema.ts");
+    assert.ok(schema?.includes("export const widgets = pgTable("));
+    assert.ok(schema?.includes("widgetId"));
+  });
+
+  it("drops collection foreign keys when foreign-keys is false (remit)", async () => {
+    const host = await remitHost();
+    const files = await runEmit(host, { frontend: "remit", "foreign-keys": false });
+    assert.ok(files.get("schema.ts")?.includes("pgTable("));
+  });
+
+  it("writes nothing when compilerOptions.noEmit is set", async () => {
+    const host = await drizzleHost();
+    host.program.compilerOptions.noEmit = true;
+    const files = await runEmit(host, {}, "/noemit-out");
+    assert.equal(files.size, 0);
+  });
+
+  it("resolves output paths under the emitter output dir", async () => {
+    const host = await drizzleHost();
+    await runEmit(host, {}, "/custom-dir");
+    assert.ok(host.fs.has(resolvePath("/custom-dir", "schema.ts")));
   });
 });

--- a/src/integration/remit-frontend.test.ts
+++ b/src/integration/remit-frontend.test.ts
@@ -177,3 +177,147 @@ describe("remit entity front-end (buildRemitIR)", () => {
     assert.equal(anyRef, false);
   });
 });
+
+const OPTIONAL_STUB = `
+using TypeSpec.Reflection;
+
+model AccessPattern {
+  index?: string;
+  collection?: string;
+  pk?: ModelProperty[];
+  sk?: ModelProperty[];
+}
+
+extern dec entity(target: Model, entity?: valueof string, service?: valueof string);
+extern dec index(target: Model, name: valueof string, accessPattern: AccessPattern);
+extern dec label(target: ModelProperty, label: valueof string);
+`;
+
+const EXTRA_MODELS = `
+import "./electrodb.tsp";
+
+enum Priority {
+  Low: 1,
+  High: 3,
+}
+
+enum Bare {
+  A,
+  B,
+}
+
+union Mixed {
+  a: string,
+  b: int32,
+}
+
+scalar Email extends string;
+
+union AllStrings {
+  plain: string,
+  custom: Email,
+}
+
+@entity
+@index("Gadget", { pk: [Gadget.gadgetId] })
+model Gadget {
+  gadgetId: string;
+  @label("custom_col") renamed: string;
+  count: int32;
+  ratio: float32;
+  precise: float64;
+  active: boolean;
+  when: utcDateTime;
+  big: int64;
+  priority: Priority;
+  bare: Bare;
+  mixed: Mixed;
+  contact: AllStrings;
+  status: string = "new";
+}
+
+@entity("alpha", "svc")
+@index("Alpha", { pk: [Alpha.alphaId] })
+@index("byShared", { index: "gsi1", collection: "shared", pk: [Alpha.sharedKey] })
+@index("byMixed", { index: "gsi2", collection: "mixedcol", pk: [Alpha.alphaId] })
+model Alpha {
+  alphaId: string;
+  sharedKey: string;
+}
+
+@entity("beta", "svc")
+@index("Beta", { pk: [Beta.betaId] })
+@index("byShared", { index: "gsi1", collection: "shared", pk: [Beta.sharedKey] })
+@index("byMixed", { index: "gsi2", collection: "mixedcol", pk: [Beta.betaId] })
+model Beta {
+  betaId: string;
+  sharedKey: string;
+}
+`;
+
+describe("remit entity front-end (extra vocabulary)", () => {
+  let byName: Map<string, TableDef>;
+
+  before(async () => {
+    const host = await createTestHost();
+    host.addJsFile("electrodb.js", {
+      $entity: () => {},
+      $index: () => {},
+      $label: () => {},
+    });
+    host.addTypeSpecFile("electrodb.tsp", `import "./electrodb.js";\n${OPTIONAL_STUB}`);
+    host.addTypeSpecFile("main.tsp", EXTRA_MODELS);
+    await host.compile("main.tsp");
+    const { tables } = buildRemitIR(host.program);
+    byName = new Map(tables.map((t) => [t.name, t]));
+  });
+
+  it("falls back to the lower-cased model name when @entity omits the name", () => {
+    assert.equal(byName.get("Gadget")?.tableName, "gadget");
+  });
+
+  it("honours a @label as the column name", () => {
+    const renamed = byName.get("Gadget")?.fields.find((f) => f.name === "renamed");
+    assert.equal(renamed?.columnName, "custom_col");
+  });
+
+  it("resolves every primitive scalar to its column type", () => {
+    const fields = new Map(byName.get("Gadget")?.fields.map((f) => [f.name, f.type.kind]));
+    assert.equal(fields.get("count"), "integer");
+    assert.equal(fields.get("ratio"), "real");
+    assert.equal(fields.get("precise"), "doublePrecision");
+    assert.equal(fields.get("active"), "boolean");
+    assert.equal(fields.get("when"), "timestamp");
+    assert.equal(fields.get("big"), "bigint");
+  });
+
+  it("maps a numeric-valued enum and a valueless enum to textEnum", () => {
+    const priority = byName.get("Gadget")?.fields.find((f) => f.name === "priority");
+    assert.equal(priority?.type.kind, "textEnum");
+    assert.deepEqual(priority?.type.kind === "textEnum" ? priority.type.values : null, ["1", "3"]);
+    const bare = byName.get("Gadget")?.fields.find((f) => f.name === "bare");
+    assert.deepEqual(bare?.type.kind === "textEnum" ? bare.type.values : null, ["A", "B"]);
+  });
+
+  it("stores a union with a non-string variant as jsonb", () => {
+    const mixed = byName.get("Gadget")?.fields.find((f) => f.name === "mixed");
+    assert.equal(mixed?.type.kind, "jsonb");
+  });
+
+  it("treats a union of string and a string-derived scalar as text", () => {
+    const contact = byName.get("Gadget")?.fields.find((f) => f.name === "contact");
+    assert.equal(contact?.type.kind, "text");
+  });
+
+  it("extracts a scalar default value", () => {
+    const status = byName.get("Gadget")?.fields.find((f) => f.name === "status");
+    assert.equal(status?.defaultValue, "new");
+  });
+
+  it("adds no foreign key when no member owns the shared collection attribute", () => {
+    const alpha = byName.get("Alpha");
+    const beta = byName.get("Beta");
+    assert.ok(alpha?.fields.every((f) => !f.references));
+    assert.ok(beta?.fields.every((f) => !f.references));
+  });
+});

--- a/src/ir/builder.test.ts
+++ b/src/ir/builder.test.ts
@@ -4,8 +4,10 @@ import type { DecoratorContext, Model, ModelProperty } from "@typespec/compiler"
 import { Numeric } from "@typespec/compiler";
 import { assemblePackage } from "../assembler.ts";
 import {
+  $check,
   $compositeUnique,
   $createdAt,
+  $foreignKeyDef,
   $indexDef,
   $junction,
   $maxValue,
@@ -18,6 +20,7 @@ import {
   $updatedAt,
   $uuid,
 } from "../decorators.ts";
+import { StateKeys } from "../lib.ts";
 import { buildIR, type ProgramStateAccess } from "./builder.ts";
 
 /**
@@ -855,5 +858,486 @@ describe("resolution: real-world field types (buildIR)", () => {
     const sourceTable = tables.find((t) => t.name === "Source");
     const fkField = sourceTable?.fields.find((f) => f.name === "targetId");
     assert.equal(fkField?.references?.onDelete, "cascade");
+  });
+
+  it("ignores a @references whose target model is not a @table", () => {
+    const program = createMockProgram();
+    const ctx = mockContext(program);
+
+    // Target model exists and is referenced, but was never marked @table.
+    const target: MockModel = { kind: "Model", name: "Loose", properties: new Map() };
+    const looseId: MockProp = {
+      kind: "ModelProperty",
+      name: "looseId",
+      type: mockScalar("string"),
+      optional: false,
+      model: target,
+    };
+    target.properties.set("looseId", looseId);
+
+    const source: MockModel = { kind: "Model", name: "Source", properties: new Map() };
+    const sourceId: MockProp = {
+      kind: "ModelProperty",
+      name: "sourceId",
+      type: mockScalar("string"),
+      optional: false,
+      model: source,
+    };
+    const fk: MockProp = {
+      kind: "ModelProperty",
+      name: "looseId",
+      type: mockScalar("string"),
+      optional: false,
+      model: source,
+    };
+    source.properties.set("sourceId", sourceId);
+    source.properties.set("looseId", fk);
+    $table(ctx, source as unknown as Model, "Source", "test");
+    $pk(ctx, sourceId as unknown as ModelProperty);
+    $references(ctx, fk as unknown as ModelProperty, looseId as unknown as ModelProperty);
+
+    const { tables } = buildIR(program);
+    const fkField = tables
+      .find((t) => t.name === "Source")
+      ?.fields.find((f) => f.name === "looseId");
+    assert.equal(fkField?.references, undefined);
+  });
+
+  it("leaves a composite foreign key's foreignTable empty when the target is not a @table", () => {
+    const program = createMockProgram();
+    const ctx = mockContext(program);
+
+    const target: MockModel = { kind: "Model", name: "Loose", properties: new Map() };
+    const tA: MockProp = {
+      kind: "ModelProperty",
+      name: "a",
+      type: mockScalar("string"),
+      optional: false,
+      model: target,
+    };
+    target.properties.set("a", tA);
+
+    const source: MockModel = { kind: "Model", name: "Source", properties: new Map() };
+    const sA: MockProp = {
+      kind: "ModelProperty",
+      name: "a",
+      type: mockScalar("string"),
+      optional: false,
+      model: source,
+    };
+    source.properties.set("a", sA);
+    $table(ctx, source as unknown as Model, "Source", "test");
+    $foreignKeyDef(
+      ctx,
+      source as unknown as Model,
+      "loose_fk",
+      [sA] as unknown as ModelProperty[],
+      [tA] as unknown as ModelProperty[],
+    );
+
+    const { tables } = buildIR(program);
+    assert.equal(tables.find((t) => t.name === "Source")?.foreignKeys[0].foreignTable, "");
+  });
+
+  it("maps a RESTRICT @references onDelete to restrict", () => {
+    const program = createMockProgram();
+    const ctx = mockContext(program);
+
+    const target: MockModel = { kind: "Model", name: "Target", properties: new Map() };
+    const targetId: MockProp = {
+      kind: "ModelProperty",
+      name: "targetId",
+      type: mockScalar("string"),
+      optional: false,
+      model: target,
+    };
+    target.properties.set("targetId", targetId);
+    $table(ctx, target as unknown as Model, "Target", "test");
+    $pk(ctx, targetId as unknown as ModelProperty);
+
+    const source: MockModel = { kind: "Model", name: "Source", properties: new Map() };
+    const sourceId: MockProp = {
+      kind: "ModelProperty",
+      name: "sourceId",
+      type: mockScalar("string"),
+      optional: false,
+      model: source,
+    };
+    const fk: MockProp = {
+      kind: "ModelProperty",
+      name: "targetId",
+      type: mockScalar("string"),
+      optional: false,
+      model: source,
+    };
+    source.properties.set("sourceId", sourceId);
+    source.properties.set("targetId", fk);
+    $table(ctx, source as unknown as Model, "Source", "test");
+    $pk(ctx, sourceId as unknown as ModelProperty);
+    $references(
+      ctx,
+      fk as unknown as ModelProperty,
+      targetId as unknown as ModelProperty,
+      "RESTRICT",
+    );
+
+    const { tables } = buildIR(program);
+    const fkField = tables
+      .find((t) => t.name === "Source")
+      ?.fields.find((f) => f.name === "targetId");
+    assert.equal(fkField?.references?.onDelete, "restrict");
+  });
+
+  it("skips non-Model entries in table state", () => {
+    const program = createMockProgram();
+    const ctx = mockContext(program);
+    const model: MockModel = { kind: "Model", name: "Row", properties: new Map() };
+    const rowId: MockProp = {
+      kind: "ModelProperty",
+      name: "rowId",
+      type: mockScalar("string"),
+      optional: false,
+      model,
+    };
+    model.properties.set("rowId", rowId);
+    $table(ctx, model as unknown as Model, "Row", "test");
+    $pk(ctx, rowId as unknown as ModelProperty);
+    // A stray non-Model target in the same state map must be ignored.
+    program.stateMap(StateKeys.table).set({ kind: "Interface" }, { name: "X", service: "s" });
+
+    const { tables } = buildIR(program);
+    assert.equal(tables.length, 1);
+    assert.equal(tables[0].name, "Row");
+  });
+
+  it("carries a @check expression into field constraints", () => {
+    const program = createMockProgram();
+    const ctx = mockContext(program);
+    const model: MockModel = { kind: "Model", name: "Row", properties: new Map() };
+    const rowId: MockProp = {
+      kind: "ModelProperty",
+      name: "rowId",
+      type: mockScalar("string"),
+      optional: false,
+      model,
+    };
+    const email: MockProp = {
+      kind: "ModelProperty",
+      name: "email",
+      type: mockScalar("string"),
+      optional: false,
+      model,
+    };
+    model.properties.set("rowId", rowId);
+    model.properties.set("email", email);
+    $table(ctx, model as unknown as Model, "Row", "test");
+    $pk(ctx, rowId as unknown as ModelProperty);
+    $check(ctx, email as unknown as ModelProperty, "email LIKE '%@%'");
+
+    const { tables } = buildIR(program);
+    const field = tables[0].fields.find((f) => f.name === "email");
+    assert.equal(field?.constraints?.check, "email LIKE '%@%'");
+  });
+
+  it("extracts a literal default value from a property", () => {
+    const program = createMockProgram();
+    const ctx = mockContext(program);
+    const model: MockModel = { kind: "Model", name: "Row", properties: new Map() };
+    const rowId: MockProp = {
+      kind: "ModelProperty",
+      name: "rowId",
+      type: mockScalar("string"),
+      optional: false,
+      model,
+    };
+    const status = {
+      kind: "ModelProperty" as const,
+      name: "status",
+      type: mockScalar("string"),
+      optional: false,
+      model,
+      default: { value: "active" },
+    };
+    model.properties.set("rowId", rowId);
+    model.properties.set("status", status as unknown as MockProp);
+    $table(ctx, model as unknown as Model, "Row", "test");
+    $pk(ctx, rowId as unknown as ModelProperty);
+
+    const { tables } = buildIR(program);
+    const field = tables[0].fields.find((f) => f.name === "status");
+    assert.equal(field?.defaultValue, "active");
+  });
+
+  it("extracts a raw primitive default value", () => {
+    const program = createMockProgram();
+    const ctx = mockContext(program);
+    const model: MockModel = { kind: "Model", name: "Row", properties: new Map() };
+    const rowId: MockProp = {
+      kind: "ModelProperty",
+      name: "rowId",
+      type: mockScalar("string"),
+      optional: false,
+      model,
+    };
+    const count = {
+      kind: "ModelProperty" as const,
+      name: "count",
+      type: mockScalar("int32"),
+      optional: false,
+      model,
+      default: 7,
+    };
+    model.properties.set("rowId", rowId);
+    model.properties.set("count", count as unknown as MockProp);
+    $table(ctx, model as unknown as Model, "Row", "test");
+    $pk(ctx, rowId as unknown as ModelProperty);
+
+    const { tables } = buildIR(program);
+    assert.equal(tables[0].fields.find((f) => f.name === "count")?.defaultValue, 7);
+  });
+
+  it("ignores an unrecognized default value shape", () => {
+    const program = createMockProgram();
+    const ctx = mockContext(program);
+    const model: MockModel = { kind: "Model", name: "Row", properties: new Map() };
+    const rowId: MockProp = {
+      kind: "ModelProperty",
+      name: "rowId",
+      type: mockScalar("string"),
+      optional: false,
+      model,
+    };
+    const weird = {
+      kind: "ModelProperty" as const,
+      name: "weird",
+      type: mockScalar("string"),
+      optional: false,
+      model,
+      default: { kind: "SomethingElse" },
+    };
+    model.properties.set("rowId", rowId);
+    model.properties.set("weird", weird as unknown as MockProp);
+    $table(ctx, model as unknown as Model, "Row", "test");
+    $pk(ctx, rowId as unknown as ModelProperty);
+
+    const { tables } = buildIR(program);
+    assert.equal(tables[0].fields.find((f) => f.name === "weird")?.defaultValue, undefined);
+  });
+
+  it("extracts an enum-member default value", () => {
+    const program = createMockProgram();
+    const ctx = mockContext(program);
+    const model: MockModel = { kind: "Model", name: "Row", properties: new Map() };
+    const rowId: MockProp = {
+      kind: "ModelProperty",
+      name: "rowId",
+      type: mockScalar("string"),
+      optional: false,
+      model,
+    };
+    const state = {
+      kind: "ModelProperty" as const,
+      name: "state",
+      type: mockScalar("string"),
+      optional: false,
+      model,
+      default: { kind: "EnumMember", name: "Open", value: "open" },
+    };
+    model.properties.set("rowId", rowId);
+    model.properties.set("state", state as unknown as MockProp);
+    $table(ctx, model as unknown as Model, "Row", "test");
+    $pk(ctx, rowId as unknown as ModelProperty);
+
+    const { tables } = buildIR(program);
+    const field = tables[0].fields.find((f) => f.name === "state");
+    assert.equal(field?.defaultValue, "open");
+  });
+
+  it("builds a composite foreign key from @foreignKeyDef", () => {
+    const program = createMockProgram();
+    const ctx = mockContext(program);
+
+    const target: MockModel = { kind: "Model", name: "Target", properties: new Map() };
+    const tA: MockProp = {
+      kind: "ModelProperty",
+      name: "a",
+      type: mockScalar("string"),
+      optional: false,
+      model: target,
+    };
+    const tB: MockProp = {
+      kind: "ModelProperty",
+      name: "b",
+      type: mockScalar("string"),
+      optional: false,
+      model: target,
+    };
+    target.properties.set("a", tA);
+    target.properties.set("b", tB);
+    $table(ctx, target as unknown as Model, "Target", "test");
+
+    const source: MockModel = { kind: "Model", name: "Source", properties: new Map() };
+    const sA: MockProp = {
+      kind: "ModelProperty",
+      name: "a",
+      type: mockScalar("string"),
+      optional: false,
+      model: source,
+    };
+    const sB: MockProp = {
+      kind: "ModelProperty",
+      name: "b",
+      type: mockScalar("string"),
+      optional: false,
+      model: source,
+    };
+    source.properties.set("a", sA);
+    source.properties.set("b", sB);
+    $table(ctx, source as unknown as Model, "Source", "test");
+    $foreignKeyDef(
+      ctx,
+      source as unknown as Model,
+      "source_target_fk",
+      [sA, sB] as unknown as ModelProperty[],
+      [tA, tB] as unknown as ModelProperty[],
+    );
+
+    const { tables } = buildIR(program);
+    const sourceTable = tables.find((t) => t.name === "Source");
+    assert.equal(sourceTable?.foreignKeys.length, 1);
+    assert.deepEqual(sourceTable?.foreignKeys[0], {
+      name: "source_target_fk",
+      columns: ["a", "b"],
+      foreignTable: "Target",
+      foreignColumns: ["a", "b"],
+    });
+  });
+
+  it("accepts decorator columns supplied as a marshalled tuple value", () => {
+    const program = createMockProgram();
+    const ctx = mockContext(program);
+    const model: MockModel = { kind: "Model", name: "Row", properties: new Map() };
+    const a: MockProp = {
+      kind: "ModelProperty",
+      name: "a",
+      type: mockScalar("string"),
+      optional: false,
+      model,
+    };
+    const b: MockProp = {
+      kind: "ModelProperty",
+      name: "b",
+      type: mockScalar("string"),
+      optional: false,
+      model,
+    };
+    model.properties.set("a", a);
+    model.properties.set("b", b);
+    $table(ctx, model as unknown as Model, "Row", "test");
+    // Emulate the compiled-TypeSpec marshalling: a { values } tuple wrapper.
+    program
+      .stateMap(StateKeys.indexDef)
+      .set(model, [{ name: "row_ab_idx", columns: { values: [a, b] }, unique: false }]);
+
+    const { tables } = buildIR(program);
+    assert.deepEqual(tables[0].indexes[0].columns, ["a", "b"]);
+  });
+
+  it("resolves int64, float32, float64, and boolean scalars", () => {
+    const program = createMockProgram();
+    const ctx = mockContext(program);
+    const model: MockModel = { kind: "Model", name: "Row", properties: new Map() };
+    const rowId: MockProp = {
+      kind: "ModelProperty",
+      name: "rowId",
+      type: mockScalar("string"),
+      optional: false,
+      model,
+    };
+    model.properties.set("rowId", rowId);
+    for (const [name, scalar] of [
+      ["big", "int64"],
+      ["ratio", "float32"],
+      ["precise", "float64"],
+      ["flag", "boolean"],
+    ] as const) {
+      model.properties.set(name, {
+        kind: "ModelProperty",
+        name,
+        type: mockScalar(scalar),
+        optional: false,
+        model,
+      });
+    }
+    $table(ctx, model as unknown as Model, "Row", "test");
+    $pk(ctx, rowId as unknown as ModelProperty);
+
+    const { tables } = buildIR(program);
+    const byName = new Map(tables[0].fields.map((f) => [f.name, f.type.kind]));
+    assert.equal(byName.get("big"), "bigint");
+    assert.equal(byName.get("ratio"), "real");
+    assert.equal(byName.get("precise"), "doublePrecision");
+    assert.equal(byName.get("flag"), "boolean");
+  });
+
+  it("recurses into a base scalar and falls back to text for an unknown scalar", () => {
+    const program = createMockProgram();
+    const ctx = mockContext(program);
+    const model: MockModel = { kind: "Model", name: "Row", properties: new Map() };
+    const rowId: MockProp = {
+      kind: "ModelProperty",
+      name: "rowId",
+      type: mockScalar("string"),
+      optional: false,
+      model,
+    };
+    // A custom scalar whose base is `int32` resolves through the recursion.
+    const customInt = { kind: "Scalar", name: "Rating", baseScalar: mockScalar("int32") };
+    // A custom scalar with no known base and no maxLength falls back to text.
+    const opaque = { kind: "Scalar", name: "Opaque" };
+    model.properties.set("rowId", rowId);
+    model.properties.set("rating", {
+      kind: "ModelProperty",
+      name: "rating",
+      type: customInt as unknown as ReturnType<typeof mockScalar>,
+      optional: false,
+      model,
+    });
+    model.properties.set("blob", {
+      kind: "ModelProperty",
+      name: "blob",
+      type: opaque as unknown as ReturnType<typeof mockScalar>,
+      optional: false,
+      model,
+    });
+    $table(ctx, model as unknown as Model, "Row", "test");
+    $pk(ctx, rowId as unknown as ModelProperty);
+
+    const { tables } = buildIR(program);
+    const byName = new Map(tables[0].fields.map((f) => [f.name, f.type.kind]));
+    assert.equal(byName.get("rating"), "integer");
+    assert.equal(byName.get("blob"), "text");
+  });
+});
+
+describe("toModelProperties input validation", () => {
+  it("throws when decorator columns are neither an array nor a tuple value", () => {
+    const program = createMockProgram();
+    const ctx = mockContext(program);
+    const model: MockModel = { kind: "Model", name: "Row", properties: new Map() };
+    const rowId: MockProp = {
+      kind: "ModelProperty",
+      name: "rowId",
+      type: mockScalar("string"),
+      optional: false,
+      model,
+    };
+    model.properties.set("rowId", rowId);
+    $table(ctx, model as unknown as Model, "Row", "test");
+    program
+      .stateMap(StateKeys.indexDef)
+      .set(model, [{ name: "bad_idx", columns: 42, unique: false }]);
+
+    assert.throws(() => buildIR(program), /Expected a ModelProperty\[\] or tuple value/);
   });
 });

--- a/src/ir/relation-graph.test.ts
+++ b/src/ir/relation-graph.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import { bookstoreTables } from "../fixtures/bookstore-ir.ts";
 import type { ManyRelation, ManyThroughRelation, OneRelation } from "./relation-graph.ts";
 import { buildRelationGraph, deriveOneRelationName } from "./relation-graph.ts";
+import type { TableDef } from "./types.ts";
 
 describe("deriveOneRelationName", () => {
   it('strips "Id" suffix: authorId → author', () => {
@@ -15,6 +16,67 @@ describe("deriveOneRelationName", () => {
 
   it("returns field name unchanged if no Id suffix", () => {
     assert.equal(deriveOneRelationName("name"), "name");
+  });
+});
+
+describe("buildRelationGraph edge cases", () => {
+  function table(over: Partial<TableDef> & { name: string }): TableDef {
+    return {
+      service: "test",
+      tableName: over.name.toLowerCase(),
+      primaryKey: { tableName: over.name.toLowerCase(), columns: ["id"], isComposite: false },
+      fields: [],
+      foreignKeys: [],
+      isJunction: false,
+      indexes: [],
+      uniqueConstraints: [],
+      ...over,
+    };
+  }
+
+  it("skips a junction that does not have exactly two references", () => {
+    const parent = table({ name: "Parent" });
+    // A junction carrying three FK-bearing fields is not a two-sided join and is skipped.
+    const triple = table({
+      name: "Triple",
+      isJunction: true,
+      fields: [
+        {
+          name: "aId",
+          columnName: "a_id",
+          type: { kind: "text" },
+          nullable: false,
+          createdAt: false,
+          updatedAt: false,
+          references: { tableName: "Parent", fieldName: "id" },
+        },
+        {
+          name: "bId",
+          columnName: "b_id",
+          type: { kind: "text" },
+          nullable: false,
+          createdAt: false,
+          updatedAt: false,
+          references: { tableName: "Parent", fieldName: "id" },
+        },
+        {
+          name: "cId",
+          columnName: "c_id",
+          type: { kind: "text" },
+          nullable: false,
+          createdAt: false,
+          updatedAt: false,
+          references: { tableName: "Parent", fieldName: "id" },
+        },
+      ],
+    });
+
+    const graph = buildRelationGraph([parent, triple]);
+    const tripleRels = graph.get("Triple");
+    assert.ok(tripleRels);
+    // Three "one" relations, but no many-through (junction rule needs exactly two).
+    assert.ok(tripleRels.every((r) => r.kind === "one"));
+    assert.equal(tripleRels.length, 3);
   });
 });
 


### PR DESCRIPTION
Raise line coverage to ~99% with real behavioral tests that exercise previously-uncovered paths (emitter entrypoint, both IR front-ends, and the generators). No production code or coverage-gate changes.