### PR TITLE
fix: add default export condition so CJS consumers can resolve generated package

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -58,6 +58,7 @@ function generatePackageJson(config: EmitterConfig): string {
       ".": {
         types: "./dist/index.d.ts",
         import: "./dist/index.js",
+        default: "./dist/index.js",
       },
     },
     scripts: {

--- a/src/integration/assembly.test.ts
+++ b/src/integration/assembly.test.ts
@@ -56,6 +56,19 @@ describe("package assembly", () => {
     assert.ok(pkg.exports["."]);
     assert.equal(pkg.exports["."].import, "./dist/index.js");
     assert.equal(pkg.exports["."].types, "./dist/index.d.ts");
+    assert.equal(pkg.exports["."].default, "./dist/index.js");
+  });
+
+  it("package.json exports a require/default condition for CJS consumers", () => {
+    const content = files.get("package.json");
+    assert.ok(content);
+    const pkg = JSON.parse(content);
+    const conditions = Object.keys(pkg.exports["."]);
+    assert.ok(
+      conditions.includes("default"),
+      "exports must include a default condition so CJS resolvers (drizzle-kit) can resolve the package",
+    );
+    assert.equal(conditions.at(-1), "default", "default must be the last condition");
   });
 
   it("package.json includes build and prepare scripts", () => {


### PR DESCRIPTION
## What

The package.json emitted for the generated drizzle package declared only `types` and `import` conditions in its `exports` map. CJS resolvers — notably drizzle-kit, which bundles `drizzle.config.ts` via esbuild in a require context — find no matching condition and throw `ERR_PACKAGE_PATH_NOT_EXPORTED`, breaking any consumer that runs `drizzle-kit push`/`generate` against the generated schema.

Adding a `default` condition (last, as the catch-all) lets CJS resolution find the entry point. The emitted package is genuine ESM (`type: "module"`, tsc ESM output); esbuild and Node ≥22's require-of-ESM both load the ESM file under the `default` condition, so no separate CJS build is needed.

## Proof

Against the emitted package, self-referencing CJS `require.resolve`:

- before (only `types` + `import`) → `ERR_PACKAGE_PATH_NOT_EXPORTED`
- after (adds `default`) → resolves to `./dist/index.js`

Full suite green (414 tests, `assembler.ts` 100% coverage). Assembly test extended to assert the `default` condition is present and last.